### PR TITLE
Add Phase 1 research dashboard

### DIFF
--- a/.quartz/quartz.config.ts
+++ b/.quartz/quartz.config.ts
@@ -28,8 +28,11 @@ const config: QuartzConfig = {
       ".quartz/**",
       ".quartz-cache/**",
 
-      // Meridian infrastructure  
+      // Meridian infrastructure
       ".meridian/**",
+
+      // Phase 1 research dashboard (static HTML, served as-is)
+      "phase1/**",
 
       // Development infrastructure
       ".git/**",

--- a/index.md
+++ b/index.md
@@ -5,7 +5,12 @@ subtitle: Accelerating Governance Innovation in Web3
 ---
 
 > [!info] Call to Action
-> If you want to contribute to gov/acc, please consider completing a [Harmonica session](https://app.harmonica.chat/chat?s=hst_a51081812ed9) to map open problems DAOs are facing, their potential solutions, and who is working on them (whether researching or building). 
+> If you want to contribute to gov/acc, please consider completing a [Harmonica session](https://app.harmonica.chat/chat?s=hst_a51081812ed9) to map open problems DAOs are facing, their potential solutions, and who is working on them (whether researching or building).
+
+> [!abstract] Phase 1 Research Results
+> Explore the interactive dashboard from our Phase 1 structured interviews — 19 completed conversations mapping 10 governance problems, 21 proposed solutions, and 30 actors across the ecosystem.
+>
+> **[View Phase 1 Dashboard →](./phase1/)**
 
 ## Overview
 

--- a/phase1/actors.html
+++ b/phase1/actors.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>gov/acc — Actors & Projects Network</title>
+<script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+<style>
+  body { margin: 0; background: #0d1117; color: #c9d1d9; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; overflow: hidden; }
+  h1 { text-align: center; padding: 16px 0 0; font-size: 1.4em; font-weight: 500; margin: 0; }
+  h1 span { color: #7ee787; }
+  p.sub { text-align: center; color: #8b949e; font-size: 0.85em; margin: 4px 0 8px; }
+  .legend { position: absolute; bottom: 20px; left: 20px; font-size: 0.8em; color: #8b949e; }
+  .legend div { display: flex; align-items: center; gap: 8px; margin: 4px 0; }
+  .legend .dot { width: 12px; height: 12px; border-radius: 50%; }
+  svg { display: block; }
+  .tooltip { position: absolute; background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 8px 12px; font-size: 0.82em; pointer-events: none; opacity: 0; transition: opacity 0.15s; max-width: 280px; line-height: 1.4; }
+  .tooltip b { color: #f0f6fc; }
+  .tooltip .cat { color: #8b949e; font-size: 0.9em; }
+</style>
+</head>
+<body>
+<h1>gov/acc Phase 1 — <span>Actors & Projects Network</span></h1>
+<p class="sub">Who's working on what — connections based on shared solution domains · mentioned by 19 participants</p>
+<div class="tooltip" id="tip"></div>
+<div class="legend">
+  <div><div class="dot" style="background: #f85149"></div> Governance Infra</div>
+  <div><div class="dot" style="background: #ffa657"></div> Reputation & Identity</div>
+  <div><div class="dot" style="background: #d2a8ff"></div> Sensemaking</div>
+  <div><div class="dot" style="background: #79c0ff"></div> Financial & Compensation</div>
+  <div><div class="dot" style="background: #7ee787"></div> Security & Verification</div>
+  <div><div class="dot" style="background: #ff7b72"></div> Research & Frameworks</div>
+  <div><div class="dot" style="background: #8b949e"></div> Service Providers</div>
+</div>
+<script>
+const cats = {
+  infra: '#f85149',
+  reputation: '#ffa657',
+  sense: '#d2a8ff',
+  finance: '#79c0ff',
+  security: '#7ee787',
+  research: '#ff7b72',
+  service: '#8b949e',
+};
+
+const nodes = [
+  // Governance Infrastructure
+  { id: 'Metagov', cat: 'infra', desc: 'Constitutional design, KOI, RIDs, Interop program', size: 18, mentioned: 6 },
+  { id: 'Aragon', cat: 'infra', desc: 'DAO tooling, governance frameworks', size: 12, mentioned: 2 },
+  { id: 'Tally', cat: 'infra', desc: 'Proposal tracking, governance dashboards', size: 10, mentioned: 2 },
+  { id: 'Agora', cat: 'infra', desc: 'Governance hub for proposal review/voting', size: 8, mentioned: 1 },
+  { id: 'Scroll DAO', cat: 'infra', desc: 'Delegate accelerator, phased governance, co-creation', size: 12, mentioned: 3 },
+
+  // Reputation & Identity
+  { id: 'DeepDAO', cat: 'reputation', desc: 'Contribution tracking, reputation systems', size: 10, mentioned: 2 },
+  { id: 'Forward', cat: 'reputation', desc: 'Delegate programs, reputation frameworks', size: 9, mentioned: 1 },
+  { id: 'Kokonut Network', cat: 'reputation', desc: 'Merit-based governance', size: 8, mentioned: 1 },
+  { id: 'Wasabi', cat: 'reputation', desc: 'Soulbound tokens, rage quit mechanics', size: 8, mentioned: 1 },
+  { id: 'Hats Protocol', cat: 'reputation', desc: 'Role-based access, merit governance', size: 8, mentioned: 1 },
+
+  // Sensemaking
+  { id: 'Polis', cat: 'sense', desc: 'Opinion clustering, collective intelligence', size: 11, mentioned: 2 },
+  { id: 'Lighthouse', cat: 'sense', desc: 'Signals protocol — values, not votes', size: 9, mentioned: 1 },
+  { id: 'Mission Public', cat: 'sense', desc: 'Deliberation experiments (Cosmos)', size: 9, mentioned: 1 },
+  { id: 'NewPublic', cat: 'sense', desc: 'Community coordination tools', size: 8, mentioned: 1 },
+
+  // Financial & Compensation
+  { id: 'Karpatkey', cat: 'finance', desc: 'Treasury management, DeFi strategies', size: 9, mentioned: 1 },
+  { id: 'Steakhouse', cat: 'finance', desc: 'Financial reporting, analytics', size: 8, mentioned: 1 },
+  { id: 'a16z', cat: 'finance', desc: 'Network token framework, "end of foundations"', size: 11, mentioned: 2 },
+
+  // Security & Verification
+  { id: 'ENS Labs', cat: 'security', desc: 'Universal resolver, security infra, veto.ensdao.eth', size: 12, mentioned: 3 },
+  { id: 'VERP', cat: 'security', desc: 'Biometric identity + sensor networks for physical verification', size: 9, mentioned: 1 },
+  { id: 'Immunefi', cat: 'security', desc: 'Bug bounties, vulnerability disclosure', size: 8, mentioned: 1 },
+  { id: 'immediacy.ai', cat: 'security', desc: 'AI-powered sim-juries, programmatic ethics', size: 9, mentioned: 1 },
+
+  // Research & Frameworks
+  { id: 'Othman (GMS)', cat: 'research', desc: 'Governance Memory System — 5-layer framework', size: 11, mentioned: 1 },
+  { id: 'Durgadas', cat: 'research', desc: 'Tensegrity, Prevolution, social architecture', size: 10, mentioned: 1 },
+  { id: 'Regis Chapman', cat: 'research', desc: 'Beyond game theory, paradox navigation', size: 9, mentioned: 1 },
+  { id: 'Ellie Rennie', cat: 'research', desc: 'Ethnographic governance research, Telescope bot', size: 9, mentioned: 1 },
+  { id: 'accessor.eth', cat: 'research', desc: 'ENS governance maximalism, security research', size: 10, mentioned: 1 },
+
+  // Service Providers
+  { id: 'SeedGov', cat: 'service', desc: 'Professional delegate services', size: 8, mentioned: 1 },
+  { id: 'Curialab', cat: 'service', desc: 'Professional delegate services', size: 8, mentioned: 1 },
+  { id: 'L2Beat', cat: 'service', desc: 'Decentralization metrics, delegate services', size: 9, mentioned: 2 },
+  { id: 'anode.gg', cat: 'service', desc: 'Governance tooling', size: 7, mentioned: 1 },
+];
+
+// Links: shared solution domains, co-mentions, or direct collaboration
+const links = [
+  // Governance infra cluster
+  { source: 'Metagov', target: 'Aragon', v: 3 },
+  { source: 'Metagov', target: 'Polis', v: 3 },
+  { source: 'Metagov', target: 'Mission Public', v: 2 },
+  { source: 'Metagov', target: 'Othman (GMS)', v: 4 },
+  { source: 'Metagov', target: 'Ellie Rennie', v: 3 },
+  { source: 'Metagov', target: 'Durgadas', v: 2 },
+  { source: 'Metagov', target: 'Scroll DAO', v: 2 },
+  { source: 'Metagov', target: 'Lighthouse', v: 2 },
+
+  // Reputation cluster
+  { source: 'DeepDAO', target: 'Forward', v: 3 },
+  { source: 'DeepDAO', target: 'Kokonut Network', v: 2 },
+  { source: 'Kokonut Network', target: 'Wasabi', v: 3 },
+  { source: 'Wasabi', target: 'Hats Protocol', v: 3 },
+  { source: 'Hats Protocol', target: 'Kokonut Network', v: 2 },
+  { source: 'Forward', target: 'Scroll DAO', v: 2 },
+
+  // Sensemaking cluster
+  { source: 'Polis', target: 'Lighthouse', v: 3 },
+  { source: 'Polis', target: 'NewPublic', v: 2 },
+  { source: 'Mission Public', target: 'Polis', v: 2 },
+  { source: 'Lighthouse', target: 'NewPublic', v: 2 },
+
+  // Finance cluster
+  { source: 'Karpatkey', target: 'Steakhouse', v: 3 },
+  { source: 'a16z', target: 'Karpatkey', v: 2 },
+  { source: 'Tally', target: 'Karpatkey', v: 2 },
+  { source: 'Tally', target: 'Agora', v: 3 },
+
+  // Security cluster
+  { source: 'ENS Labs', target: 'accessor.eth', v: 4 },
+  { source: 'ENS Labs', target: 'Immunefi', v: 2 },
+  { source: 'VERP', target: 'ENS Labs', v: 1 },
+  { source: 'immediacy.ai', target: 'Durgadas', v: 1 },
+
+  // Research interconnections
+  { source: 'Othman (GMS)', target: 'Ellie Rennie', v: 2 },
+  { source: 'Durgadas', target: 'Regis Chapman', v: 3 },
+  { source: 'Othman (GMS)', target: 'Durgadas', v: 2 },
+  { source: 'Regis Chapman', target: 'Metagov', v: 1 },
+  { source: 'accessor.eth', target: 'Scroll DAO', v: 1 },
+
+  // Service providers
+  { source: 'SeedGov', target: 'Curialab', v: 3 },
+  { source: 'SeedGov', target: 'L2Beat', v: 2 },
+  { source: 'Curialab', target: 'L2Beat', v: 2 },
+  { source: 'L2Beat', target: 'Scroll DAO', v: 2 },
+  { source: 'L2Beat', target: 'Tally', v: 2 },
+
+  // Cross-cluster connections
+  { source: 'Scroll DAO', target: 'DeepDAO', v: 2 },
+  { source: 'Aragon', target: 'Hats Protocol', v: 2 },
+  { source: 'a16z', target: 'ENS Labs', v: 2 },
+  { source: 'Scroll DAO', target: 'Karpatkey', v: 1 },
+  { source: 'Metagov', target: 'NewPublic', v: 2 },
+];
+
+const W = window.innerWidth;
+const H = window.innerHeight - 80;
+
+const svg = d3.select('body').append('svg')
+  .attr('width', W)
+  .attr('height', H)
+  .style('margin-top', '0');
+
+const tip = d3.select('#tip');
+
+const simulation = d3.forceSimulation(nodes)
+  .force('link', d3.forceLink(links).id(d => d.id).distance(d => 100 - d.v * 10).strength(d => d.v * 0.08))
+  .force('charge', d3.forceManyBody().strength(-250))
+  .force('center', d3.forceCenter(W / 2, H / 2))
+  .force('collision', d3.forceCollide().radius(d => d.size + 8))
+  .force('x', d3.forceX(W / 2).strength(0.03))
+  .force('y', d3.forceY(H / 2).strength(0.03));
+
+const link = svg.append('g')
+  .selectAll('line')
+  .data(links)
+  .join('line')
+  .attr('stroke', '#21262d')
+  .attr('stroke-width', d => d.v * 0.8)
+  .attr('stroke-opacity', 0.6);
+
+const node = svg.append('g')
+  .selectAll('g')
+  .data(nodes)
+  .join('g')
+  .call(d3.drag()
+    .on('start', (e, d) => { if (!e.active) simulation.alphaTarget(0.3).restart(); d.fx = d.x; d.fy = d.y; })
+    .on('drag', (e, d) => { d.fx = e.x; d.fy = e.y; })
+    .on('end', (e, d) => { if (!e.active) simulation.alphaTarget(0); d.fx = null; d.fy = null; })
+  );
+
+node.append('circle')
+  .attr('r', d => d.size)
+  .attr('fill', d => cats[d.cat])
+  .attr('fill-opacity', 0.85)
+  .attr('stroke', '#0d1117')
+  .attr('stroke-width', 1.5);
+
+node.append('text')
+  .text(d => d.id)
+  .attr('dy', d => d.size + 14)
+  .attr('text-anchor', 'middle')
+  .attr('fill', '#c9d1d9')
+  .attr('font-size', '11px')
+  .attr('font-family', '-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif');
+
+node.on('mouseover', (e, d) => {
+  // Find connected nodes
+  const connected = new Set();
+  links.forEach(l => {
+    const s = typeof l.source === 'object' ? l.source.id : l.source;
+    const t = typeof l.target === 'object' ? l.target.id : l.target;
+    if (s === d.id) connected.add(t);
+    if (t === d.id) connected.add(s);
+  });
+
+  // Highlight
+  node.select('circle').attr('fill-opacity', n => n.id === d.id || connected.has(n.id) ? 1 : 0.15);
+  node.select('text').attr('fill-opacity', n => n.id === d.id || connected.has(n.id) ? 1 : 0.15);
+  link.attr('stroke-opacity', l => {
+    const s = typeof l.source === 'object' ? l.source.id : l.source;
+    const t = typeof l.target === 'object' ? l.target.id : l.target;
+    return s === d.id || t === d.id ? 0.8 : 0.05;
+  }).attr('stroke', l => {
+    const s = typeof l.source === 'object' ? l.source.id : l.source;
+    const t = typeof l.target === 'object' ? l.target.id : l.target;
+    return s === d.id || t === d.id ? '#484f58' : '#21262d';
+  });
+
+  const catNames = { infra: 'Governance Infra', reputation: 'Reputation & Identity', sense: 'Sensemaking', finance: 'Financial', security: 'Security & Verification', research: 'Research & Frameworks', service: 'Service Provider' };
+  tip.html('<b>' + d.id + '</b><br><span class="cat">' + catNames[d.cat] + '</span><br><br>' + d.desc + '<br><br>Mentioned by ' + d.mentioned + ' participant' + (d.mentioned > 1 ? 's' : '') + '<br>Connected to ' + connected.size + ' other actors')
+    .style('opacity', 1)
+    .style('left', (e.pageX + 14) + 'px')
+    .style('top', (e.pageY - 14) + 'px');
+})
+.on('mousemove', (e) => {
+  tip.style('left', (e.pageX + 14) + 'px').style('top', (e.pageY - 14) + 'px');
+})
+.on('mouseout', () => {
+  node.select('circle').attr('fill-opacity', 0.85);
+  node.select('text').attr('fill-opacity', 1);
+  link.attr('stroke-opacity', 0.6).attr('stroke', '#21262d');
+  tip.style('opacity', 0);
+});
+
+simulation.on('tick', () => {
+  link
+    .attr('x1', d => d.source.x)
+    .attr('y1', d => d.source.y)
+    .attr('x2', d => d.target.x)
+    .attr('y2', d => d.target.y);
+  node.attr('transform', d => 'translate(' + d.x + ',' + d.y + ')');
+});
+</script>
+</body>
+</html>

--- a/phase1/index.html
+++ b/phase1/index.html
@@ -1,0 +1,1524 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>gov/acc — Phase 1 Research Dashboard</title>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,500;0,9..144,700;1,9..144,300&family=JetBrains+Mono:wght@300;400;500&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #131920;
+    --border: #1e2836;
+    --text: #b8c4d0;
+    --text-dim: #5a6a7a;
+    --text-bright: #e8edf3;
+    --accent: #7ee787;
+    --critical: #f85149;
+    --high: #ffa657;
+    --medium: #ffd866;
+    --lower: #7ee787;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'JetBrains Mono', monospace;
+    height: 100vh;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Noise texture */
+  body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.025'/%3E%3C/svg%3E");
+    pointer-events: none;
+    z-index: 999;
+  }
+
+  /* Tab bar */
+  .tab-bar {
+    display: flex;
+    align-items: stretch;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    padding: 0 16px;
+    flex-shrink: 0;
+    z-index: 100;
+    position: relative;
+    gap: 1px;
+  }
+  .tab-bar .logo {
+    display: flex;
+    align-items: center;
+    padding: 0 16px 0 4px;
+    font-family: 'Fraunces', serif;
+    font-size: 1.05em;
+    font-weight: 500;
+    color: var(--text-bright);
+    letter-spacing: -0.03em;
+    white-space: nowrap;
+    border-right: 1px solid var(--border);
+    margin-right: 8px;
+  }
+  .tab-bar .logo em { color: var(--accent); font-style: italic; font-weight: 300; }
+  .tab {
+    padding: 12px 18px;
+    font-size: 0.68em;
+    font-family: 'JetBrains Mono', monospace;
+    font-weight: 400;
+    color: var(--text-dim);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color 0.15s, border-color 0.15s;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    white-space: nowrap;
+    user-select: none;
+  }
+  .tab:hover { color: var(--text); }
+  .tab.active {
+    color: var(--text-bright);
+    border-bottom-color: var(--accent);
+  }
+
+  /* Tab content */
+  .tab-content {
+    flex: 1;
+    overflow: hidden;
+    position: relative;
+  }
+  .tab-pane {
+    display: none;
+    position: absolute;
+    inset: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+  .tab-pane.active { display: block; }
+  .tab-pane.no-scroll { overflow: hidden; }
+
+  /* ========== OVERVIEW TAB ========== */
+  .overview {
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+  }
+  .overview-hero {
+    padding: 56px 48px 40px;
+    position: relative;
+  }
+  .overview-hero::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(ellipse at 30% 40%, rgba(126,231,135,0.04) 0%, transparent 60%),
+                radial-gradient(ellipse at 70% 60%, rgba(248,81,73,0.03) 0%, transparent 50%);
+    pointer-events: none;
+  }
+  .overview-hero h1 {
+    font-family: 'Fraunces', serif;
+    font-size: 3em;
+    font-weight: 700;
+    color: var(--text-bright);
+    letter-spacing: -0.04em;
+    line-height: 1;
+    margin-bottom: 8px;
+    position: relative;
+  }
+  .overview-hero h1 em {
+    display: block;
+    font-weight: 300;
+    font-style: italic;
+    color: var(--accent);
+    font-size: 0.65em;
+    margin-top: 4px;
+  }
+  .overview-hero .tagline {
+    font-size: 0.82em;
+    color: var(--text-dim);
+    font-weight: 300;
+    max-width: 640px;
+    line-height: 1.7;
+    margin-top: 16px;
+    position: relative;
+  }
+  .overview-hero .tagline a {
+    color: var(--accent);
+    text-decoration: none;
+    border-bottom: 1px solid rgba(126,231,135,0.25);
+    transition: border-color 0.15s;
+  }
+  .overview-hero .tagline a:hover { border-color: var(--accent); }
+
+  /* Stats grid */
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 2px;
+    padding: 0 48px;
+    position: relative;
+  }
+  .stat-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 24px 20px;
+    text-align: center;
+    transition: border-color 0.2s;
+  }
+  .stat-card:hover { border-color: #2a3544; }
+  .stat-card .stat-val {
+    font-family: 'Fraunces', serif;
+    font-size: 2.8em;
+    font-weight: 700;
+    color: var(--text-bright);
+    line-height: 1;
+    letter-spacing: -0.03em;
+  }
+  .stat-card:nth-child(1) .stat-val { color: var(--accent); }
+  .stat-card:nth-child(2) .stat-val { color: var(--text-dim); }
+  .stat-card .stat-label {
+    font-size: 0.6em;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-top: 6px;
+    font-weight: 400;
+  }
+
+  /* Research description */
+  .overview-body {
+    padding: 40px 48px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 40px;
+    position: relative;
+  }
+  .overview-section h3 {
+    font-family: 'Fraunces', serif;
+    font-size: 1.15em;
+    font-weight: 500;
+    color: var(--text-bright);
+    letter-spacing: -0.02em;
+    margin-bottom: 12px;
+  }
+  .overview-section p {
+    font-size: 0.72em;
+    color: var(--text);
+    line-height: 1.75;
+    font-weight: 300;
+  }
+  .overview-section .method-tag {
+    display: inline-block;
+    font-size: 0.62em;
+    padding: 3px 10px;
+    border: 1px solid var(--border);
+    color: var(--text-dim);
+    margin: 4px 4px 0 0;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 400;
+  }
+
+  /* CTA */
+  .overview-cta {
+    padding: 0 48px 48px;
+    position: relative;
+  }
+  .cta-box {
+    background: linear-gradient(135deg, rgba(126,231,135,0.06) 0%, rgba(126,231,135,0.02) 100%);
+    border: 1px solid rgba(126,231,135,0.15);
+    padding: 28px 32px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+  }
+  .cta-box .cta-text {
+    font-size: 0.78em;
+    color: var(--text);
+    font-weight: 300;
+    line-height: 1.6;
+  }
+  .cta-box .cta-text strong {
+    color: var(--text-bright);
+    font-weight: 500;
+  }
+  .cta-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--accent);
+    color: var(--bg);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72em;
+    font-weight: 500;
+    padding: 12px 24px;
+    text-decoration: none;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    transition: background 0.15s, transform 0.1s;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .cta-btn:hover { background: #6cd677; transform: translateY(-1px); }
+  .cta-btn::after { content: '→'; font-size: 1.1em; }
+
+  .overview-footer {
+    padding: 16px 48px 24px;
+    font-size: 0.55em;
+    color: #2a3544;
+    font-weight: 300;
+    text-align: center;
+    letter-spacing: 0.04em;
+    border-top: 1px solid var(--border);
+    margin-top: auto;
+  }
+
+  /* ========== PROBLEMS TAB ========== */
+  #pane-problems .p-header {
+    padding: 28px 32px 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+  #pane-problems .p-header h2 {
+    font-family: 'Fraunces', serif;
+    font-size: 1.6em;
+    font-weight: 500;
+    color: var(--text-bright);
+    letter-spacing: -0.03em;
+    line-height: 1.1;
+  }
+  #pane-problems .p-header h2 em { color: var(--critical); font-style: italic; font-weight: 300; }
+  #pane-problems .p-header .meta {
+    text-align: right;
+    font-size: 0.65em;
+    color: var(--text-dim);
+    font-weight: 300;
+    line-height: 1.7;
+  }
+  #pane-problems .p-header .meta strong { color: var(--text); font-weight: 500; }
+  #pane-problems .p-subtitle {
+    padding: 6px 32px 0;
+    font-size: 0.72em;
+    color: var(--text-dim);
+    font-weight: 300;
+    max-width: 680px;
+    line-height: 1.6;
+  }
+  #pane-problems .urgency-scale {
+    display: flex;
+    gap: 16px;
+    padding: 16px 32px 12px;
+    font-size: 0.62em;
+    color: var(--text-dim);
+    font-weight: 400;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  #pane-problems .urgency-scale .us-item { display: flex; align-items: center; gap: 5px; }
+  #pane-problems .urgency-scale .us-dot { width: 8px; height: 8px; border-radius: 50%; }
+  #pane-problems .problems-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 2px;
+    padding: 0 32px 32px;
+  }
+  @media (max-width: 1100px) { #pane-problems .problems-grid { grid-template-columns: 1fr; } }
+  .problem-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 20px 24px;
+    position: relative;
+    overflow: hidden;
+    transition: border-color 0.2s, background 0.2s;
+    animation: slideUp 0.5s ease-out both;
+  }
+  .problem-card:hover { border-color: var(--severity-color); background: #151c25; }
+  .problem-card::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0;
+    width: 3px; height: 100%;
+    background: var(--severity-color);
+    opacity: 0.7;
+  }
+  .pc-top { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 12px; }
+  .pc-rank {
+    font-family: 'Fraunces', serif;
+    font-size: 2em; font-weight: 700;
+    color: var(--severity-color);
+    line-height: 1; opacity: 0.3;
+    flex-shrink: 0; min-width: 36px; text-align: right;
+  }
+  .pc-title-block { flex: 1; }
+  .pc-title {
+    font-family: 'Fraunces', serif;
+    font-size: 1.15em; font-weight: 500;
+    color: var(--text-bright);
+    line-height: 1.2; letter-spacing: -0.02em;
+  }
+  .pc-severity {
+    display: inline-block;
+    font-size: 0.55em;
+    font-family: 'JetBrains Mono', monospace;
+    text-transform: uppercase; letter-spacing: 0.1em;
+    padding: 2px 8px; border-radius: 2px;
+    margin-top: 4px; font-weight: 500;
+    background: color-mix(in srgb, var(--severity-color) 12%, transparent);
+    color: var(--severity-color);
+    border: 1px solid color-mix(in srgb, var(--severity-color) 25%, transparent);
+  }
+  .pc-metrics {
+    display: flex; gap: 20px;
+    margin-bottom: 14px; padding-bottom: 12px;
+    border-bottom: 1px solid #1a2029;
+  }
+  .pc-metric { display: flex; flex-direction: column; gap: 2px; }
+  .pc-metric .val { font-size: 1.4em; font-weight: 500; color: var(--text-bright); line-height: 1; }
+  .pc-metric .label {
+    font-size: 0.6em; color: var(--text-dim);
+    text-transform: uppercase; letter-spacing: 0.08em; font-weight: 300;
+  }
+  .breadth-bar { display: flex; gap: 3px; margin-bottom: 14px; }
+  .breadth-bar .seg { height: 4px; flex: 1; border-radius: 1px; background: #1a2029; }
+  .breadth-bar .seg.filled { background: var(--severity-color); opacity: 0.6; }
+  .pc-participants { font-size: 0.68em; color: var(--text-dim); line-height: 1.6; margin-bottom: 14px; font-weight: 300; }
+  .pc-participants b { color: var(--text); font-weight: 500; }
+  .pc-participants .name {
+    display: inline-block; padding: 0 4px; margin: 1px 0;
+    border-radius: 2px; background: rgba(255,255,255,0.03);
+    border: 1px solid #1a2029; color: var(--text); font-weight: 400;
+  }
+  .pc-solutions-header {
+    font-size: 0.58em; color: var(--text-dim);
+    text-transform: uppercase; letter-spacing: 0.1em;
+    margin-bottom: 6px; font-weight: 400;
+  }
+  .pc-solutions { display: flex; flex-wrap: wrap; gap: 4px; }
+  .pc-sol {
+    font-size: 0.65em; padding: 3px 8px; border-radius: 2px;
+    background: rgba(126,231,135,0.06); border: 1px solid rgba(126,231,135,0.12);
+    color: var(--accent); font-weight: 400; cursor: default;
+  }
+  .pc-sol .sol-mentions { color: var(--text-dim); font-size: 0.88em; }
+  .pc-connections { margin-top: 10px; font-size: 0.6em; color: #3d4a58; font-weight: 300; font-style: italic; }
+  @keyframes slideUp {
+    from { opacity: 0; transform: translateY(16px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  /* ========== URGENCY TAB ========== */
+  #pane-urgency { display: none; }
+  #pane-urgency.active { display: flex; flex-direction: column; }
+  #pane-urgency .urg-header {
+    padding: 20px 32px 0;
+    text-align: center;
+  }
+  #pane-urgency .urg-header h2 {
+    font-family: 'Fraunces', serif;
+    font-size: 1.4em; font-weight: 500;
+    color: var(--text-bright); letter-spacing: -0.02em;
+  }
+  #pane-urgency .urg-header h2 em { color: var(--critical); font-style: italic; font-weight: 300; }
+  #pane-urgency .urg-sub {
+    font-size: 0.72em; color: var(--text-dim);
+    font-weight: 300; margin-top: 4px;
+  }
+  #pane-urgency .urg-chart { flex: 1; min-height: 0; }
+
+  /* ========== SOLUTIONS TAB ========== */
+  #pane-solutions .sol-header {
+    text-align: center; padding: 20px 20px 6px;
+  }
+  #pane-solutions .sol-header h2 {
+    font-family: 'Fraunces', serif;
+    font-size: 1.35em; font-weight: 500;
+    color: var(--text-bright); letter-spacing: -0.02em;
+  }
+  #pane-solutions .sol-header h2 em { color: var(--accent); font-style: italic; font-weight: 300; }
+  #pane-solutions .sol-sub {
+    color: var(--text-dim); font-size: 0.72em; margin-top: 4px; font-weight: 300;
+  }
+  #pane-solutions .x-axis {
+    display: flex; align-items: center; justify-content: center;
+    gap: 6px; padding: 14px 20px 2px;
+    color: var(--text-dim); font-size: 0.68em;
+    text-transform: uppercase; letter-spacing: 0.08em;
+  }
+  #pane-solutions .x-axis .arrow {
+    flex: 0 0 auto; width: 40px; height: 1px;
+    background: linear-gradient(90deg, transparent, #484f58);
+    position: relative;
+  }
+  #pane-solutions .x-axis .arrow::after {
+    content: ''; position: absolute; right: 0; top: -3px;
+    border: 3px solid transparent; border-left: 5px solid #484f58;
+  }
+  #pane-solutions .x-axis .arrow.left {
+    background: linear-gradient(90deg, #484f58, transparent);
+  }
+  #pane-solutions .x-axis .arrow.left::after {
+    right: auto; left: 0; border-left: none; border-right: 5px solid #484f58;
+  }
+  #pane-solutions .landscape {
+    display: grid; grid-template-columns: repeat(5, 1fr);
+    gap: 2px; padding: 8px 36px 24px;
+    min-height: calc(100% - 120px);
+  }
+  .maturity-col { display: flex; flex-direction: column; gap: 2px; }
+  .col-header {
+    text-align: center; padding: 10px 4px;
+    font-size: 0.78em; font-weight: 500;
+    color: var(--text-bright); letter-spacing: 0.02em;
+    border-bottom: 1px solid #21262d;
+  }
+  .col-header .stage-num {
+    display: block; font-size: 2em; font-weight: 300;
+    color: #21262d; line-height: 1; margin-bottom: 2px;
+  }
+  .col-body { flex: 1; display: flex; flex-direction: column; gap: 6px; padding: 8px 4px; }
+  .sol-card {
+    position: relative; border-radius: 8px; padding: 10px 11px;
+    cursor: default; transition: transform 0.2s, box-shadow 0.2s, background 0.15s;
+    border: 1px solid transparent; background: #161b22;
+  }
+  .sol-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+    z-index: 20; border-color: var(--cat-color);
+  }
+  .sol-card .card-top { display: flex; align-items: flex-start; gap: 8px; margin-bottom: 6px; }
+  .sol-card .dot { flex-shrink: 0; width: 8px; height: 8px; border-radius: 50%; margin-top: 4px; background: var(--cat-color); }
+  .sol-card .sname { font-size: 0.82em; font-weight: 500; color: #e6edf3; line-height: 1.25; }
+  .sol-card .mentions-badge {
+    margin-left: auto; flex-shrink: 0;
+    background: rgba(255,255,255,0.06); color: var(--text-dim);
+    font-size: 0.7em; padding: 2px 6px; border-radius: 10px; white-space: nowrap;
+  }
+  .sol-card .smeta { font-size: 0.72em; color: var(--text-dim); line-height: 1.35; }
+  .sol-card .smeta .cat-label { color: var(--cat-color); font-weight: 500; }
+  .sol-card .problems-bar { display: flex; gap: 2px; margin-top: 6px; }
+  .sol-card .problems-bar .pip { height: 3px; flex: 1; border-radius: 1.5px; background: var(--cat-color); opacity: 0.5; }
+  .sol-card .detail {
+    max-height: 0; overflow: hidden;
+    transition: max-height 0.3s, opacity 0.2s; opacity: 0;
+  }
+  .sol-card:hover .detail { max-height: 200px; opacity: 1; margin-top: 8px; }
+  .sol-card .detail .section { font-size: 0.72em; color: var(--text-dim); margin-bottom: 4px; line-height: 1.4; }
+  .sol-card .detail .section b { color: #c9d1d9; font-weight: 500; }
+  .sol-card .detail .problem-tags { display: flex; flex-wrap: wrap; gap: 3px; margin-top: 4px; }
+  .sol-card .detail .problem-tag {
+    font-size: 0.65em; padding: 2px 6px; border-radius: 3px;
+    background: rgba(255,255,255,0.05); color: #c9d1d9; border: 1px solid #21262d;
+  }
+  .sol-card.dimmed { opacity: 0.12; transform: scale(0.97); }
+  #pane-solutions .sol-legend {
+    display: flex; flex-wrap: wrap; justify-content: center;
+    gap: 12px 20px; padding: 8px 20px 20px;
+  }
+  .sol-legend-item {
+    display: flex; align-items: center; gap: 6px;
+    font-size: 0.72em; color: var(--text-dim);
+    cursor: pointer; transition: opacity 0.15s;
+  }
+  .sol-legend-item:hover { opacity: 0.7; }
+  .sol-legend-item.dimmed { opacity: 0.25; }
+  .sol-legend-item .swatch { width: 10px; height: 10px; border-radius: 3px; }
+
+  /* ========== WARDLEY MAP TAB ========== */
+  #pane-wardley.active { display: block; }
+  #pane-wardley .w-header {
+    position: absolute; top: 0; left: 0; right: 0; z-index: 10;
+    padding: 20px 28px 0;
+    display: flex; justify-content: space-between; align-items: flex-start;
+    pointer-events: none;
+  }
+  #pane-wardley .w-header h2 {
+    font-family: 'Fraunces', serif;
+    font-size: 1.4em; font-weight: 500;
+    color: var(--text-bright); letter-spacing: -0.02em; line-height: 1.1;
+  }
+  #pane-wardley .w-header h2 em { color: var(--accent); font-style: italic; font-weight: 300; }
+  #pane-wardley .w-subtitle {
+    font-size: 0.68em; color: var(--text-dim);
+    margin-top: 4px; font-weight: 300; max-width: 480px; line-height: 1.5;
+  }
+  #pane-wardley .w-caveat {
+    font-size: 0.6em; color: #3d4a58; margin-top: 3px;
+    font-weight: 300; font-style: italic; max-width: 420px; line-height: 1.4;
+  }
+  #pane-wardley .w-meta {
+    text-align: right; font-size: 0.6em;
+    color: var(--text-dim); font-weight: 300; line-height: 1.6; padding-top: 4px;
+  }
+  #pane-wardley svg#wardley-map { width: 100%; height: 100%; }
+  #pane-wardley .w-tooltip {
+    position: fixed; z-index: 50;
+    background: #161d26; border: 1px solid #2a3544; border-radius: 2px;
+    padding: 14px 16px; font-size: 11px;
+    pointer-events: none; opacity: 0; transition: opacity 0.12s;
+    max-width: 290px; line-height: 1.55;
+    box-shadow: 0 12px 40px rgba(0,0,0,0.6);
+  }
+  #pane-wardley .w-tooltip .tt-name { font-family: 'Fraunces', serif; font-size: 15px; color: var(--text-bright); margin-bottom: 2px; }
+  #pane-wardley .w-tooltip .tt-cat { font-weight: 500; font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
+  #pane-wardley .w-tooltip .tt-tags { display: flex; flex-wrap: wrap; gap: 3px; margin: 6px 0; }
+  #pane-wardley .w-tooltip .tt-tag { font-size: 9.5px; padding: 1px 6px; border: 1px solid #2a3544; color: var(--text); border-radius: 1px; background: rgba(255,255,255,0.02); }
+  #pane-wardley .w-tooltip .tt-section { color: var(--text-dim); margin-top: 5px; }
+  #pane-wardley .w-tooltip .tt-section b { color: var(--text); font-weight: 500; }
+  #pane-wardley .w-tooltip .tt-mentions { color: #3d4a58; margin-top: 8px; padding-top: 6px; border-top: 1px solid #1e2836; font-size: 10px; }
+  #pane-wardley .w-legend {
+    position: absolute; bottom: 16px; left: 50%; transform: translateX(-50%);
+    z-index: 10; display: flex; gap: 14px; padding: 8px 16px;
+    background: rgba(13,17,23,0.85); border: 1px solid #1e2836;
+    border-radius: 2px; backdrop-filter: blur(8px);
+  }
+  #pane-wardley .w-legend .lg {
+    display: flex; align-items: center; gap: 5px;
+    font-size: 9.5px; color: var(--text-dim);
+    cursor: pointer; transition: opacity 0.15s; font-weight: 400; white-space: nowrap;
+  }
+  #pane-wardley .w-legend .lg:hover { color: var(--text); }
+  #pane-wardley .w-legend .lg.dimmed { opacity: 0.15; }
+  #pane-wardley .w-legend .lg .sw { width: 7px; height: 7px; border-radius: 1px; }
+  @keyframes nodeIn {
+    from { opacity: 0; transform: scale(0.3); }
+    to { opacity: 1; transform: scale(1); }
+  }
+  .node-g { animation: nodeIn 0.4s ease-out both; }
+
+  /* ========== ACTORS TAB ========== */
+  #pane-actors .actors-tooltip {
+    position: absolute; background: #161b22; border: 1px solid #30363d;
+    border-radius: 6px; padding: 8px 12px; font-size: 0.82em;
+    pointer-events: none; opacity: 0; transition: opacity 0.15s;
+    max-width: 280px; line-height: 1.4; z-index: 50;
+  }
+  #pane-actors .actors-tooltip b { color: #f0f6fc; }
+  #pane-actors .actors-tooltip .cat { color: var(--text-dim); font-size: 0.9em; }
+  #pane-actors .a-header {
+    text-align: center; padding: 16px 0 0;
+    position: absolute; top: 0; left: 0; right: 0; z-index: 10;
+    pointer-events: none;
+  }
+  #pane-actors .a-header h2 {
+    font-family: 'Fraunces', serif;
+    font-size: 1.4em; font-weight: 500;
+    color: var(--text-bright); letter-spacing: -0.02em;
+  }
+  #pane-actors .a-header h2 em { color: var(--accent); font-style: italic; font-weight: 300; }
+  #pane-actors .a-sub {
+    color: var(--text-dim); font-size: 0.72em; margin: 4px 0 8px; font-weight: 300;
+  }
+  #pane-actors .actors-legend {
+    position: absolute; bottom: 20px; left: 20px;
+    font-size: 0.72em; color: var(--text-dim); z-index: 10;
+  }
+  #pane-actors .actors-legend div { display: flex; align-items: center; gap: 8px; margin: 4px 0; }
+  #pane-actors .actors-legend .adot { width: 10px; height: 10px; border-radius: 50%; }
+
+  /* ========== SANKEY TAB ========== */
+  #pane-sankey .sk-header {
+    text-align: center; padding: 20px 0 0;
+  }
+  #pane-sankey .sk-header h2 {
+    font-family: 'Fraunces', serif;
+    font-size: 1.4em; font-weight: 500;
+    color: var(--text-bright); letter-spacing: -0.02em;
+  }
+  #pane-sankey .sk-header h2 em { color: var(--accent); font-style: italic; font-weight: 300; }
+  #pane-sankey .sk-sub {
+    font-size: 0.72em; color: var(--text-dim);
+    margin: 4px 0 0; font-weight: 300;
+  }
+  #pane-sankey.active { display: flex; flex-direction: column; }
+  #pane-sankey .sk-chart { flex: 1; min-height: 0; }
+</style>
+</head>
+<body>
+
+<!-- TAB BAR -->
+<div class="tab-bar">
+  <div class="logo">gov/<em>acc</em></div>
+  <div class="tab active" data-tab="overview">Overview</div>
+  <div class="tab" data-tab="problems">Problems</div>
+  <div class="tab" data-tab="urgency">Urgency</div>
+  <div class="tab" data-tab="solutions">Solutions</div>
+  <div class="tab" data-tab="wardley">Wardley Map</div>
+  <div class="tab" data-tab="actors">Actors</div>
+  <div class="tab" data-tab="sankey">Sankey</div>
+</div>
+
+<!-- TAB CONTENT -->
+<div class="tab-content">
+
+  <!-- ==================== OVERVIEW ==================== -->
+  <div class="tab-pane active" id="pane-overview">
+    <div class="overview">
+      <div class="overview-hero">
+        <h1>gov/acc<em>Accelerating Governance Innovation in Web3</em></h1>
+        <div class="tagline">
+          Phase 1 structured research examining the biggest governance challenges in web3 — and the solutions emerging to address them. Conducted via <a href="https://harmonica.chat" target="_blank">Harmonica</a> structured interviews with governance practitioners, delegates, researchers, and builders across the ecosystem. In collaboration with <a href="https://metagov.org" target="_blank">Metagov</a>.
+        </div>
+      </div>
+
+      <div class="stats-grid">
+        <div class="stat-card">
+          <div class="stat-val">19</div>
+          <div class="stat-label">Completed</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-val">33</div>
+          <div class="stat-label">Engaged</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-val">10</div>
+          <div class="stat-label">Problems</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-val">21</div>
+          <div class="stat-label">Solutions</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-val">30</div>
+          <div class="stat-label">Actors</div>
+        </div>
+      </div>
+
+      <div class="overview-body">
+        <div class="overview-section">
+          <h3>What is gov/acc?</h3>
+          <p>A research initiative exploring how we can accelerate governance innovation in web3. While the ecosystem has experimented with novel governance structures like DAOs, many implementations fall short — plagued by voter apathy, token plutocracy, governance theater, and institutional amnesia. We set out to understand these problems systematically and map the solution landscape.</p>
+        </div>
+        <div class="overview-section">
+          <h3>Methodology</h3>
+          <p>We conducted 19 structured interviews using Harmonica, an AI-facilitated deliberation platform. Each 20-minute session explored participants' experience with governance problems, proposed solutions, and the actors building them. The structured format ensures consistent coverage while allowing organic deep-dives.</p>
+          <div style="margin-top: 10px;">
+            <span class="method-tag">Structured interviews</span>
+            <span class="method-tag">AI-facilitated</span>
+            <span class="method-tag">20 min sessions</span>
+            <span class="method-tag">Jan–Feb 2026</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="overview-cta">
+        <div class="cta-box">
+          <div class="cta-text">
+            <strong>Haven't participated yet?</strong> We're still collecting perspectives from governance practitioners, delegates, and researchers. Your experience matters — the interview takes about 20 minutes and is facilitated by AI.
+          </div>
+          <a href="https://app.harmonica.chat/chat?s=hst_a51081812ed9" target="_blank" class="cta-btn">Participate</a>
+        </div>
+      </div>
+
+      <div class="overview-footer">gov/acc Phase 1 · Harmonica × Metagov · Data from 19 completed structured interviews · Jan–Feb 2026</div>
+    </div>
+  </div>
+
+  <!-- ==================== PROBLEMS ==================== -->
+  <div class="tab-pane" id="pane-problems">
+    <div class="p-header">
+      <div><h2>gov/acc — <em>Problems Map</em></h2></div>
+      <div class="meta">Phase 1 Research<br><strong>19</strong> completed interviews<br>Jan–Feb 2026</div>
+    </div>
+    <div class="p-subtitle">10 governance problems identified across 19 structured interviews, ranked by composite urgency score (breadth × 60% + depth × 40%). Each card shows who raised it, how deeply it was discussed, and which proposed solutions address it.</div>
+    <div class="urgency-scale">
+      <div class="us-item"><div class="us-dot" style="background:var(--critical)"></div> Critical</div>
+      <div class="us-item"><div class="us-dot" style="background:var(--high)"></div> High</div>
+      <div class="us-item"><div class="us-dot" style="background:var(--medium)"></div> Medium</div>
+      <div class="us-item"><div class="us-dot" style="background:var(--lower)"></div> Lower priority</div>
+    </div>
+    <div class="problems-grid" id="problems-grid"></div>
+  </div>
+
+  <!-- ==================== URGENCY ==================== -->
+  <div class="tab-pane no-scroll" id="pane-urgency">
+    <div class="urg-header">
+      <h2>gov/acc — <em>Urgency Matrix</em></h2>
+      <div class="urg-sub">Bubble size = number of participants who raised each problem · Position = breadth vs depth of discussion</div>
+    </div>
+    <div class="urg-chart" id="urgency-chart"></div>
+  </div>
+
+  <!-- ==================== SOLUTIONS ==================== -->
+  <div class="tab-pane" id="pane-solutions">
+    <div class="sol-header">
+      <h2>gov/acc — <em>Solutions Landscape</em></h2>
+      <div class="sol-sub">21 proposed solutions organized by maturity stage · hover for details</div>
+    </div>
+    <div class="x-axis">
+      <span class="arrow left"></span>
+      <span>Early</span>
+      <span style="color:#484f58;margin:0 4px">·</span>
+      <span>Maturity</span>
+      <span style="color:#484f58;margin:0 4px">·</span>
+      <span>Established</span>
+      <span class="arrow"></span>
+    </div>
+    <div class="landscape" id="solutions-landscape"></div>
+    <div class="sol-legend" id="solutions-legend"></div>
+  </div>
+
+  <!-- ==================== WARDLEY MAP ==================== -->
+  <div class="tab-pane no-scroll" id="pane-wardley">
+    <div class="w-header">
+      <div>
+        <h2>gov/acc — <em>Wardley Map</em></h2>
+        <div class="w-subtitle">21 governance solutions mapped by evolution stage & value chain visibility. Bubble size = participant mentions.</div>
+        <div class="w-caveat">Y-axis placement is editorial — solutions positioned from invisible infrastructure to direct participant experience.</div>
+      </div>
+      <div class="w-meta">Phase 1 Research<br><span style="color:#3d4a58;font-size:0.9em">19 completed · Jan–Feb 2026</span></div>
+    </div>
+    <svg id="wardley-map"></svg>
+    <div class="w-tooltip" id="wardley-tip"></div>
+    <div class="w-legend" id="wardley-legend"></div>
+  </div>
+
+  <!-- ==================== ACTORS ==================== -->
+  <div class="tab-pane no-scroll" id="pane-actors">
+    <div class="a-header">
+      <h2>gov/acc — <em>Actors & Projects Network</em></h2>
+      <div class="a-sub">Who's working on what — connections based on shared solution domains · mentioned by 19 participants</div>
+    </div>
+    <div class="actors-tooltip" id="actors-tip"></div>
+    <div class="actors-legend">
+      <div><div class="adot" style="background:#f85149"></div> Governance Infra</div>
+      <div><div class="adot" style="background:#ffa657"></div> Reputation & Identity</div>
+      <div><div class="adot" style="background:#d2a8ff"></div> Sensemaking</div>
+      <div><div class="adot" style="background:#79c0ff"></div> Financial & Compensation</div>
+      <div><div class="adot" style="background:#7ee787"></div> Security & Verification</div>
+      <div><div class="adot" style="background:#ff7b72"></div> Research & Frameworks</div>
+      <div><div class="adot" style="background:#8b949e"></div> Service Providers</div>
+    </div>
+    <div id="actors-container" style="width:100%;height:100%;"></div>
+  </div>
+
+  <!-- ==================== SANKEY ==================== -->
+  <div class="tab-pane no-scroll" id="pane-sankey">
+    <div class="sk-header">
+      <h2>gov/acc — <em>Problems → Solutions → Actors</em></h2>
+      <div class="sk-sub">Flow from identified problems through solution categories to the actors building them</div>
+    </div>
+    <div class="sk-chart" id="sankey-chart"></div>
+  </div>
+
+</div>
+
+<script>
+// ======================== TAB SWITCHING ========================
+const tabs = document.querySelectorAll('.tab');
+const panes = document.querySelectorAll('.tab-pane');
+const initialized = {};
+
+tabs.forEach(tab => {
+  tab.addEventListener('click', () => {
+    const target = tab.dataset.tab;
+    tabs.forEach(t => t.classList.remove('active'));
+    panes.forEach(p => p.classList.remove('active'));
+    tab.classList.add('active');
+    document.getElementById('pane-' + target).classList.add('active');
+
+    // Lazy init visualizations
+    if (!initialized[target]) {
+      initialized[target] = true;
+      if (target === 'problems') initProblems();
+      if (target === 'urgency') initUrgency();
+      if (target === 'solutions') initSolutions();
+      if (target === 'wardley') initWardley();
+      if (target === 'actors') initActors();
+      if (target === 'sankey') initSankey();
+    }
+    // Resize for Plotly
+    if (target === 'urgency') Plotly.Plots.resize('urgency-chart');
+    if (target === 'sankey') Plotly.Plots.resize('sankey-chart');
+    if (target === 'wardley') renderWardley();
+    if (target === 'actors' && window._actorsSim) window._actorsSim.alpha(0.3).restart();
+  });
+});
+
+// ======================== PROBLEMS DATA ========================
+const problemsData = [
+  { name: "Token Voting Failure & Plutocracy", breadth: 12, depth: 4.2, who: ["Eugene","Zeugh","Malachite","Hima","Marlene","Alex Soto","Trigs","Raphael","Artem","Chris","Regis","Ivey"] },
+  { name: "Governance Theater & Recentralization", breadth: 9, depth: 3.8, who: ["Coffee-crusher","Ivey","Carl","Alex Soto","Marlene","Chris","Zeugh","Hima","Trigs"] },
+  { name: "Broken Contributor Economies", breadth: 7, depth: 5.1, who: ["Marlene","Alex Soto","Coffee-crusher","Zeugh","Raphael","Malachite","Chris"] },
+  { name: "Voting Fatigue & Apathy", breadth: 8, depth: 2.8, who: ["Eugene","Martin","Trigs","Hima","Raphael","Zeugh","Marlene","Ivey"] },
+  { name: "Informal Power & Narrative Capture", breadth: 6, depth: 3.5, who: ["Othman","Zeugh","Marlene","Alex Soto","Trigs","Hima"] },
+  { name: "Institutional Amnesia", breadth: 5, depth: 5.8, who: ["Othman","Artem","Eugene","Regis","Martin"] },
+  { name: "Delegate Sustainability", breadth: 5, depth: 4.0, who: ["Marlene","Alex Soto","Zeugh","Malachite","Coffee-crusher"] },
+  { name: "Lack of Clear Purpose", breadth: 5, depth: 3.2, who: ["Eugene","Raphael","Carl","Coffee-crusher","Ivey"] },
+  { name: "Over-Reliance on Game Theory", breadth: 4, depth: 6.5, who: ["Regis","Martin","Durgadas (via Regis)","Artem"] },
+  { name: "Technical & Legal Gaps", breadth: 4, depth: 4.8, who: ["Della Foresta","Jason C","Joseph","Hima"] },
+];
+
+const solutionsForProblems = [
+  { name: "Conviction Voting", mentions: 5, problems: ["Token voting failure","Voting fatigue","Informal power"] },
+  { name: "Soulbound / Reputation Tokens", mentions: 6, problems: ["Token voting failure","Broken contributor economies","Informal power","Delegate sustainability"] },
+  { name: "Delegate Verification", mentions: 4, problems: ["Token voting failure","Delegate sustainability","Informal power"] },
+  { name: "AI Governance Agents", mentions: 4, problems: ["Voting fatigue","Token voting failure","Institutional amnesia"] },
+  { name: "AI Dispute Resolution", mentions: 2, problems: ["Technical & legal gaps","Over-reliance on game theory"] },
+  { name: "Polis / Opinion Clustering", mentions: 5, problems: ["Token voting failure","Informal power","Voting fatigue"] },
+  { name: "Signals Protocol", mentions: 3, problems: ["Token voting failure","Voting fatigue","Lack of clear purpose"] },
+  { name: "Co-creation Cycles", mentions: 4, problems: ["Governance theater","Lack of clear purpose","Token voting failure"] },
+  { name: "Governance Memory System", mentions: 3, problems: ["Institutional amnesia","Over-reliance on game theory","Governance theater"] },
+  { name: "Reference Identifiers (RIDs)", mentions: 2, problems: ["Institutional amnesia","Informal power"] },
+  { name: "Telescope Bot", mentions: 1, problems: ["Institutional amnesia","Informal power"] },
+  { name: "Tensegrity Governance", mentions: 3, problems: ["Over-reliance on game theory","Governance theater","Lack of clear purpose","Informal power"] },
+  { name: "Optimistic Governance", mentions: 4, problems: ["Voting fatigue","Governance theater"] },
+  { name: "Specialized Committees", mentions: 5, problems: ["Governance theater","Lack of clear purpose","Broken contributor economies"] },
+  { name: "Proto-DAOs / Gated Governance", mentions: 4, problems: ["Lack of clear purpose","Token voting failure","Governance theater"] },
+  { name: "Contributor Streams", mentions: 5, problems: ["Broken contributor economies","Delegate sustainability"] },
+  { name: "RPGF", mentions: 4, problems: ["Broken contributor economies","Delegate sustainability"] },
+  { name: "VE / Buyback Models", mentions: 3, problems: ["Token voting failure","Governance theater"] },
+  { name: "VERP Protocol", mentions: 1, problems: ["Technical & legal gaps","Token voting failure"] },
+  { name: "Platform Cooperatives", mentions: 2, problems: ["Governance theater","Technical & legal gaps","Lack of clear purpose"] },
+  { name: "Centralized Ops + DAO Oversight", mentions: 5, problems: ["Governance theater","Lack of clear purpose","Voting fatigue"] },
+];
+
+function matchProblem(sp, cn) {
+  const s = sp.toLowerCase(), c = cn.toLowerCase();
+  if (c.includes('token voting') && s.includes('token voting')) return true;
+  if (c.includes('governance theater') && s.includes('governance theater')) return true;
+  if (c.includes('contributor') && s.includes('contributor')) return true;
+  if (c.includes('voting fatigue') && s.includes('voting fatigue')) return true;
+  if (c.includes('informal power') && s.includes('informal power')) return true;
+  if (c.includes('institutional amnesia') && s.includes('institutional amnesia')) return true;
+  if (c.includes('delegate') && s.includes('delegate')) return true;
+  if (c.includes('clear purpose') && s.includes('clear purpose')) return true;
+  if (c.includes('game theory') && s.includes('game theory')) return true;
+  if (c.includes('technical') && s.includes('technical')) return true;
+  if (c.includes('legal') && s.includes('legal')) return true;
+  return false;
+}
+
+// ======================== PROBLEMS TAB ========================
+function initProblems() {
+  const maxBreadth = 12, maxDepth = 6.5;
+  problemsData.forEach(p => {
+    p.score = (p.breadth / maxBreadth) * 0.6 + (p.depth / maxDepth) * 0.4;
+    if (p.score > 0.7) { p.severity = 'Critical'; p.color = 'var(--critical)'; }
+    else if (p.score > 0.5) { p.severity = 'High'; p.color = 'var(--high)'; }
+    else if (p.score > 0.35) { p.severity = 'Medium'; p.color = 'var(--medium)'; }
+    else { p.severity = 'Lower'; p.color = 'var(--lower)'; }
+    p.solutions = solutionsForProblems
+      .filter(s => s.problems.some(sp => matchProblem(sp, p.name)))
+      .sort((a, b) => b.mentions - a.mentions);
+  });
+  problemsData.sort((a, b) => b.score - a.score);
+
+  function getCoOccurrence(p) {
+    const pSet = new Set(p.who);
+    const co = [];
+    problemsData.forEach(o => {
+      if (o.name === p.name) return;
+      const overlap = o.who.filter(w => pSet.has(w)).length;
+      if (overlap >= 3) co.push({ name: o.name, overlap });
+    });
+    co.sort((a, b) => b.overlap - a.overlap);
+    return co.slice(0, 3);
+  }
+
+  const grid = document.getElementById('problems-grid');
+  problemsData.forEach((p, i) => {
+    const card = document.createElement('div');
+    card.className = 'problem-card';
+    card.style.setProperty('--severity-color', p.color);
+    card.style.animationDelay = (i * 0.07) + 's';
+    const rank = String(i + 1).padStart(2, '0');
+    const coProblems = getCoOccurrence(p);
+    const coText = coProblems.length > 0
+      ? 'Co-raised with: ' + coProblems.map(c => c.name + ' (' + c.overlap + ' shared)').join(' · ')
+      : '';
+    card.innerHTML = `
+      <div class="pc-top">
+        <div class="pc-rank">${rank}</div>
+        <div class="pc-title-block">
+          <div class="pc-title">${p.name}</div>
+          <div class="pc-severity">${p.severity}</div>
+        </div>
+      </div>
+      <div class="pc-metrics">
+        <div class="pc-metric"><div class="val">${p.breadth}<span style="color:var(--text-dim);font-size:0.5em;font-weight:300">/19</span></div><div class="label">Breadth</div></div>
+        <div class="pc-metric"><div class="val">${p.depth.toFixed(1)}</div><div class="label">Avg depth (msgs)</div></div>
+        <div class="pc-metric"><div class="val">${p.solutions.length}</div><div class="label">Solutions proposed</div></div>
+        <div class="pc-metric"><div class="val">${(p.score * 100).toFixed(0)}</div><div class="label">Urgency score</div></div>
+      </div>
+      <div class="breadth-bar">${Array.from({length:19},(_,j)=>`<div class="seg ${j<p.breadth?'filled':''}"></div>`).join('')}</div>
+      <div class="pc-participants"><b>Raised by:</b> ${p.who.map(w=>`<span class="name">${w}</span>`).join(' ')}</div>
+      <div class="pc-solutions-header">Proposed solutions (${p.solutions.length})</div>
+      <div class="pc-solutions">${p.solutions.map(s=>`<div class="pc-sol">${s.name} <span class="sol-mentions">${s.mentions}×</span></div>`).join('')}</div>
+      ${coText ? `<div class="pc-connections">${coText}</div>` : ''}
+    `;
+    grid.appendChild(card);
+  });
+}
+
+// ======================== URGENCY TAB ========================
+function initUrgency() {
+  const problems = [
+    { label: "Token Voting Failure\n& Plutocracy", x: 12, y: 4.2, who: "Eugene, Zeugh, Malachite, Hima,\nMarlene, Alex Soto, Trigs, Raphael,\nArtem, Chris, Regis, Ivey" },
+    { label: "Governance Theater\n& Recentralization", x: 9, y: 3.8, who: "Coffee-crusher, Ivey, Carl, Alex Soto,\nMarlene, Chris, Zeugh, Hima, Trigs" },
+    { label: "Broken Contributor\nEconomies", x: 7, y: 5.1, who: "Marlene, Alex Soto, Coffee-crusher,\nZeugh, Raphael, Malachite, Chris" },
+    { label: "Informal Power\n& Narrative Capture", x: 6, y: 3.5, who: "Othman, Zeugh, Marlene,\nAlex Soto, Trigs, Hima" },
+    { label: "Institutional\nAmnesia", x: 5, y: 5.8, who: "Othman, Artem, Eugene,\nRegis, Martin" },
+    { label: "Lack of Clear\nPurpose", x: 5, y: 3.2, who: "Eugene, Raphael, Carl,\nCoffee-crusher, Ivey" },
+    { label: "Over-Reliance on\nGame Theory", x: 4, y: 6.5, who: "Regis, Martin, Durgadas\n(via Regis), Artem" },
+    { label: "Technical &\nLegal Gaps", x: 4, y: 4.8, who: "Della Foresta, Jason C,\nJoseph, Hima" },
+    { label: "Voting Fatigue\n& Apathy", x: 8, y: 2.8, who: "Eugene, Martin, Trigs, Hima,\nRaphael, Zeugh, Marlene, Ivey" },
+    { label: "Delegate\nSustainability", x: 5, y: 4.0, who: "Marlene, Alex Soto, Zeugh,\nMalachite, Coffee-crusher" },
+  ];
+  const x = problems.map(p=>p.x), y = problems.map(p=>p.y), text = problems.map(p=>p.label);
+  const hover = problems.map(p =>
+    '<b>' + p.label.replace('\n',' ') + '</b><br>Mentioned by: ' + p.x + ' participants<br>Avg depth: ' + p.y.toFixed(1) + ' messages<br><br>' + p.who
+  );
+  const sizes = x.map(v => v * 6 + 10);
+  const colors = problems.map(p => {
+    const score = (p.x / 12) * 0.6 + (p.y / 6.5) * 0.4;
+    if (score > 0.7) return 'rgba(248,81,73,0.9)';
+    if (score > 0.5) return 'rgba(255,166,87,0.9)';
+    if (score > 0.35) return 'rgba(255,214,102,0.9)';
+    return 'rgba(126,231,135,0.7)';
+  });
+
+  Plotly.newPlot('urgency-chart', [{
+    type: 'scatter', mode: 'markers+text',
+    x, y, text,
+    textposition: problems.map(p => {
+      if (p.label.includes('Voting Fatigue')) return 'bottom center';
+      if (p.label.includes('Delegate')) return 'top left';
+      if (p.label.includes('Lack of')) return 'bottom right';
+      if (p.label.includes('Informal')) return 'top right';
+      if (p.label.includes('Institutional')) return 'top center';
+      if (p.label.includes('Technical')) return 'top right';
+      if (p.label.includes('Game Theory')) return 'top left';
+      if (p.label.includes('Contributor')) return 'top center';
+      return 'top center';
+    }),
+    textfont: { size: 11, color: '#c9d1d9', family: 'JetBrains Mono' },
+    hovertext: hover, hoverinfo: 'text',
+    marker: { size: sizes, color: colors, line: { color: '#0d1117', width: 1.5 }, opacity: 0.9 },
+  }], {
+    paper_bgcolor: '#0d1117', plot_bgcolor: '#161b22',
+    font: { color: '#c9d1d9', family: 'JetBrains Mono, monospace' },
+    xaxis: { title: { text: 'Breadth — how many participants raised this (out of 19)', font: { size: 12 } }, gridcolor: '#21262d', range: [2.5,13.5], dtick: 2, zeroline: false },
+    yaxis: { title: { text: 'Depth — avg messages spent discussing per participant', font: { size: 12 } }, gridcolor: '#21262d', range: [2,7.5], zeroline: false },
+    margin: { l: 70, r: 40, t: 20, b: 60 },
+    annotations: [
+      { x: 11, y: 7, text: '<b>CRITICAL</b><br>broad + deep', showarrow: false, font: { size: 11, color: 'rgba(248,81,73,0.5)' } },
+      { x: 3.5, y: 2.5, text: 'niche concerns', showarrow: false, font: { size: 10, color: 'rgba(126,231,135,0.4)' } },
+    ],
+    shapes: [
+      { type:'line', x0:6.5, x1:6.5, y0:2, y1:7.5, line:{color:'#21262d',width:1,dash:'dot'} },
+      { type:'line', x0:2.5, x1:13.5, y0:4.3, y1:4.3, line:{color:'#21262d',width:1,dash:'dot'} },
+    ],
+  }, { responsive: true, displayModeBar: false });
+}
+
+// ======================== SOLUTIONS TAB ========================
+function initSolutions() {
+  const solutions = [
+    { name:"Conviction Voting", x:3.5, y:3, mentions:5, cat:"Voting Reform", problems:["Token voting failure","Voting fatigue","Informal power"], actors:["Various DAOs experimenting"], examples:"Weight votes by time held + participation history" },
+    { name:"Soulbound / Reputation Tokens", x:3, y:4, mentions:6, cat:"Reputation", problems:["Token voting failure","Broken contributor economies","Informal power","Delegate sustainability"], actors:["Kokonut Network","Wasabi","Hats Protocol","DAO Haus"], examples:"Burned to release voting power; rage quit mechanics; merit-based roles" },
+    { name:"Delegate Verification", x:3, y:3, mentions:4, cat:"Reputation", problems:["Token voting failure","Delegate sustainability","Informal power"], actors:["Scroll DAO","Forward","DeepDAO"], examples:"Verified delegate status for consistent compensation" },
+    { name:"AI Governance Agents", x:2, y:3, mentions:4, cat:"AI-Augmented", problems:["Voting fatigue","Token voting failure","Institutional amnesia"], actors:["Clawdbot builders","Martin"], examples:"Personal AI voting; NLP proposal summarization" },
+    { name:"AI Dispute Resolution", x:2, y:2, mentions:2, cat:"AI-Augmented", problems:["Technical & legal gaps","Over-reliance on game theory"], actors:["immediacy.ai"], examples:"Sim-juries interpreting programmatic ethics" },
+    { name:"Polis / Opinion Clustering", x:4, y:3, mentions:5, cat:"Sensemaking", problems:["Token voting failure","Informal power","Voting fatigue"], actors:["Polis","Metagov"], examples:"Collective sensemaking through opinion mapping" },
+    { name:"Signals Protocol", x:2.5, y:3, mentions:3, cat:"Sensemaking", problems:["Token voting failure","Voting fatigue","Lack of clear purpose"], actors:["Lighthouse"], examples:"Signal values instead of voting on outcomes" },
+    { name:"Co-creation Cycles", x:3, y:3, mentions:4, cat:"Sensemaking", problems:["Governance theater","Lack of clear purpose","Token voting failure"], actors:["Scroll DAO","NEAR"], examples:"Collaborative design processes for proposals" },
+    { name:"Governance Memory System", x:2, y:3, mentions:3, cat:"Knowledge", problems:["Institutional amnesia","Over-reliance on game theory","Governance theater"], actors:["Othman (GMS framework)"], examples:"5-layer framework: lifecycle, reviews, themes, power, diagnostics" },
+    { name:"Reference Identifiers (RIDs)", x:2.5, y:2, mentions:2, cat:"Knowledge", problems:["Institutional amnesia","Informal power"], actors:["Metagov KOI group"], examples:"Tagging knowledge objects across Discord, forums, GitHub" },
+    { name:"Telescope Bot", x:3, y:2, mentions:1, cat:"Knowledge", problems:["Institutional amnesia","Informal power"], actors:["Ellie Rennie"], examples:"Flags high-signal Discord comments for ethnographic review" },
+    { name:"Tensegrity Governance", x:1.5, y:4, mentions:3, cat:"Structural", problems:["Over-reliance on game theory","Governance theater","Lack of clear purpose","Informal power"], actors:["Durgadas"], examples:"Hold paradoxes in dynamic tension; multiple decision venues" },
+    { name:"Optimistic Governance", x:3.5, y:2, mentions:4, cat:"Structural", problems:["Voting fatigue","Governance theater"], actors:["Various L2s"], examples:"Proposals pass unless challenged" },
+    { name:"Specialized Committees", x:3.5, y:3, mentions:5, cat:"Structural", problems:["Governance theater","Lack of clear purpose","Broken contributor economies"], actors:["Scroll DAO","Coffee-crusher proposal"], examples:"Marketing, audits, treasury, proposal PM" },
+    { name:"Proto-DAOs / Gated Governance", x:2, y:3, mentions:4, cat:"Structural", problems:["Lack of clear purpose","Token voting failure","Governance theater"], actors:["Eugene (concept)","Various L2s"], examples:"Staked governance; progressive decentralization" },
+    { name:"Contributor Streams", x:3.5, y:2, mentions:5, cat:"Financial", problems:["Broken contributor economies","Delegate sustainability"], actors:["Scroll DAO","Various DAOs"], examples:"Bounties → Project Grants → Core Contributor Streams" },
+    { name:"RPGF", x:3, y:2, mentions:4, cat:"Financial", problems:["Broken contributor economies","Delegate sustainability"], actors:["Optimism","Various"], examples:"Retroactive public goods funding" },
+    { name:"VE / Buyback Models", x:4.5, y:2, mentions:3, cat:"Financial", problems:["Token voting failure","Governance theater"], actors:["Curve","Aerodrome"], examples:"Vote-escrowed tokens; buyback-and-burn" },
+    { name:"VERP Protocol", x:1.5, y:2, mentions:1, cat:"Verification", problems:["Technical & legal gaps","Token voting failure"], actors:["Della Foresta"], examples:"Biometric identity + sensor networks" },
+    { name:"Platform Cooperatives", x:2, y:3, mentions:2, cat:"Alternative", problems:["Governance theater","Technical & legal gaps","Lack of clear purpose"], actors:["Joseph","Public AI Network"], examples:"Platforms as public infrastructure" },
+    { name:"Centralized Ops + DAO Oversight", x:3.5, y:3, mentions:5, cat:"Alternative", problems:["Governance theater","Lack of clear purpose","Voting fatigue"], actors:["a16z (concept)","Various L2s"], examples:"Foundations run day-to-day; DAO approves budgets/strategy" },
+  ];
+  const catColors = {
+    "Voting Reform":"#f85149","Reputation":"#ffa657","AI-Augmented":"#d2a8ff",
+    "Sensemaking":"#79c0ff","Knowledge":"#56d364","Structural":"#ff7b72",
+    "Financial":"#ffd866","Verification":"#7ee787","Alternative":"#8b949e",
+  };
+  function getColumn(x) { if(x<1.75)return 0; if(x<2.75)return 1; if(x<3.25)return 2; if(x<4.25)return 3; return 4; }
+  const colLabels=['Idea','Research','Pilot','Production','Established'], colNums=['01','02','03','04','05'];
+  const buckets=[[],[],[],[],[]];
+  solutions.forEach(s=>{ buckets[getColumn(s.x)].push(s); });
+  buckets.forEach(b=>b.sort((a,bb)=>bb.y-a.y));
+
+  const landscape = document.getElementById('solutions-landscape');
+  buckets.forEach((items, colIdx) => {
+    const col = document.createElement('div'); col.className = 'maturity-col';
+    const header = document.createElement('div'); header.className = 'col-header';
+    header.innerHTML = '<span class="stage-num">'+colNums[colIdx]+'</span>'+colLabels[colIdx];
+    col.appendChild(header);
+    const body = document.createElement('div'); body.className = 'col-body';
+    items.forEach(s => {
+      const card = document.createElement('div'); card.className = 'sol-card'; card.dataset.cat = s.cat;
+      card.style.setProperty('--cat-color', catColors[s.cat]);
+      card.innerHTML = `
+        <div class="card-top"><div class="dot"></div><div class="sname">${s.name}</div><div class="mentions-badge">${s.mentions}${s.mentions===1?' mention':' mentions'}</div></div>
+        <div class="smeta"><span class="cat-label">${s.cat}</span> · ${s.y} problem${s.y!==1?'s':''} addressed</div>
+        <div class="problems-bar">${Array.from({length:s.y},()=>'<div class="pip"></div>').join('')}</div>
+        <div class="detail">
+          <div class="section"><b>Addresses:</b></div>
+          <div class="problem-tags">${s.problems.map(p=>'<span class="problem-tag">'+p+'</span>').join('')}</div>
+          <div class="section" style="margin-top:6px"><b>Actors:</b> ${s.actors.join(', ')}</div>
+          <div class="section"><b>How:</b> ${s.examples}</div>
+        </div>
+      `;
+      body.appendChild(card);
+    });
+    col.appendChild(body);
+    landscape.appendChild(col);
+  });
+
+  // Legend
+  const legendEl = document.getElementById('solutions-legend');
+  const categories = [...new Set(solutions.map(s=>s.cat))];
+  let activeFilter = null;
+  categories.forEach(cat => {
+    const item = document.createElement('div'); item.className = 'sol-legend-item';
+    item.innerHTML = '<div class="swatch" style="background:'+catColors[cat]+'"></div>'+cat;
+    item.addEventListener('click', () => {
+      if (activeFilter === cat) {
+        activeFilter = null;
+        document.querySelectorAll('.sol-card').forEach(c=>c.classList.remove('dimmed'));
+        document.querySelectorAll('.sol-legend-item').forEach(l=>l.classList.remove('dimmed'));
+      } else {
+        activeFilter = cat;
+        document.querySelectorAll('.sol-card').forEach(c=>{ c.classList.toggle('dimmed', c.dataset.cat !== cat); });
+        document.querySelectorAll('.sol-legend-item').forEach(l=>{ l.classList.toggle('dimmed', !l.textContent.includes(cat)); });
+      }
+    });
+    legendEl.appendChild(item);
+  });
+}
+
+// ======================== WARDLEY MAP TAB ========================
+const wardleySolutions = [
+  { name:"Conviction Voting", ex:3.5, vc:0.88, mentions:5, cat:"Voting Reform", problems:["Token voting failure","Voting fatigue","Informal power"], actors:["Various DAOs"], examples:"Weight votes by time held + participation history" },
+  { name:"Optimistic Governance", ex:3.5, vc:0.84, mentions:4, cat:"Structural", problems:["Voting fatigue","Governance theater"], actors:["Various L2s"], examples:"Proposals pass unless challenged" },
+  { name:"Polis / Opinion Clustering", ex:4, vc:0.82, mentions:5, cat:"Sensemaking", problems:["Token voting failure","Informal power","Voting fatigue"], actors:["Polis","Metagov"], examples:"Collective sensemaking through opinion mapping" },
+  { name:"Contributor Streams", ex:3.5, vc:0.78, mentions:5, cat:"Financial", problems:["Broken contributor economies","Delegate sustainability"], actors:["Scroll DAO","Various DAOs"], examples:"Bounties → Project Grants → Core Contributor Streams" },
+  { name:"Centralized Ops + DAO Oversight", ex:3.5, vc:0.74, mentions:5, cat:"Alternative", problems:["Governance theater","Lack of clear purpose","Voting fatigue"], actors:["a16z (concept)","Various L2s"], examples:"Foundations run day-to-day; DAO approves budgets/strategy" },
+  { name:"Proto-DAOs / Gated Governance", ex:2, vc:0.72, mentions:4, cat:"Structural", problems:["Lack of clear purpose","Token voting failure","Governance theater"], actors:["Eugene (concept)","Various L2s"], examples:"Staked governance; progressive decentralization" },
+  { name:"Specialized Committees", ex:3.5, vc:0.65, mentions:5, cat:"Structural", problems:["Governance theater","Lack of clear purpose","Broken contributor economies"], actors:["Scroll DAO","Coffee-crusher"], examples:"Marketing, audits, treasury, proposal PM" },
+  { name:"Co-creation Cycles", ex:3, vc:0.62, mentions:4, cat:"Sensemaking", problems:["Governance theater","Lack of clear purpose","Token voting failure"], actors:["Scroll DAO","NEAR"], examples:"Collaborative design processes for proposals" },
+  { name:"Signals Protocol", ex:2.5, vc:0.60, mentions:3, cat:"Sensemaking", problems:["Token voting failure","Voting fatigue","Lack of clear purpose"], actors:["Lighthouse"], examples:"Signal values instead of voting on outcomes" },
+  { name:"RPGF", ex:3, vc:0.58, mentions:4, cat:"Financial", problems:["Broken contributor economies","Delegate sustainability"], actors:["Optimism","Various"], examples:"Retroactive public goods funding" },
+  { name:"AI Governance Agents", ex:2, vc:0.55, mentions:4, cat:"AI-Augmented", problems:["Voting fatigue","Token voting failure","Institutional amnesia"], actors:["Clawdbot builders","Martin"], examples:"Personal AI voting; NLP proposal summarization" },
+  { name:"Platform Cooperatives", ex:2, vc:0.52, mentions:2, cat:"Alternative", problems:["Governance theater","Technical & legal gaps","Lack of clear purpose"], actors:["Joseph","Public AI Network"], examples:"Platforms as public infrastructure" },
+  { name:"Soulbound / Reputation Tokens", ex:3, vc:0.48, mentions:6, cat:"Reputation", problems:["Token voting failure","Broken contributor economies","Informal power","Delegate sustainability"], actors:["Kokonut Network","Wasabi","Hats Protocol","DAO Haus"], examples:"Burned to release voting power; merit-based roles" },
+  { name:"Delegate Verification", ex:3, vc:0.45, mentions:4, cat:"Reputation", problems:["Token voting failure","Delegate sustainability","Informal power"], actors:["Scroll DAO","Forward","DeepDAO"], examples:"Verified delegate status for consistent compensation" },
+  { name:"VE / Buyback Models", ex:4.5, vc:0.38, mentions:3, cat:"Financial", problems:["Token voting failure","Governance theater"], actors:["Curve","Aerodrome"], examples:"Vote-escrowed tokens; buyback-and-burn" },
+  { name:"AI Dispute Resolution", ex:2, vc:0.33, mentions:2, cat:"AI-Augmented", problems:["Technical & legal gaps","Over-reliance on game theory"], actors:["immediacy.ai"], examples:"Sim-juries interpreting programmatic ethics" },
+  { name:"Governance Memory System", ex:2, vc:0.28, mentions:3, cat:"Knowledge", problems:["Institutional amnesia","Over-reliance on game theory","Governance theater"], actors:["Othman (GMS framework)"], examples:"5-layer framework: lifecycle, reviews, themes, power, diagnostics" },
+  { name:"Reference IDs (RIDs)", ex:2.5, vc:0.22, mentions:2, cat:"Knowledge", problems:["Institutional amnesia","Informal power"], actors:["Metagov KOI group"], examples:"Tagging knowledge objects across platforms" },
+  { name:"Telescope Bot", ex:3, vc:0.19, mentions:1, cat:"Knowledge", problems:["Institutional amnesia","Informal power"], actors:["Ellie Rennie"], examples:"Flags high-signal Discord comments" },
+  { name:"Tensegrity Governance", ex:1.5, vc:0.13, mentions:3, cat:"Structural", problems:["Over-reliance on game theory","Governance theater","Lack of clear purpose","Informal power"], actors:["Durgadas"], examples:"Hold paradoxes in dynamic tension" },
+  { name:"VERP Protocol", ex:1.5, vc:0.08, mentions:1, cat:"Verification", problems:["Technical & legal gaps","Token voting failure"], actors:["Della Foresta"], examples:"Biometric identity + sensor networks" },
+];
+
+const wardleyCatColors = {
+  "Voting Reform":"#f85149","Reputation":"#ffa657","AI-Augmented":"#d2a8ff",
+  "Sensemaking":"#79c0ff","Knowledge":"#56d364","Structural":"#ff7b72",
+  "Financial":"#ffd866","Verification":"#7ee787","Alternative":"#8b949e",
+};
+
+const wardleyDeps = [
+  ["Conviction Voting","VE / Buyback Models"],["Conviction Voting","Soulbound / Reputation Tokens"],
+  ["Optimistic Governance","Specialized Committees"],["Polis / Opinion Clustering","Signals Protocol"],
+  ["Polis / Opinion Clustering","Co-creation Cycles"],["Contributor Streams","RPGF"],
+  ["Contributor Streams","Delegate Verification"],["Centralized Ops + DAO Oversight","Specialized Committees"],
+  ["Proto-DAOs / Gated Governance","AI Governance Agents"],["Co-creation Cycles","Governance Memory System"],
+  ["Signals Protocol","Governance Memory System"],["Soulbound / Reputation Tokens","Delegate Verification"],
+  ["Delegate Verification","Reference IDs (RIDs)"],["AI Governance Agents","AI Dispute Resolution"],
+  ["AI Governance Agents","Governance Memory System"],["Governance Memory System","Reference IDs (RIDs)"],
+  ["Governance Memory System","Telescope Bot"],["Tensegrity Governance","VERP Protocol"],
+  ["Platform Cooperatives","Tensegrity Governance"],["RPGF","Soulbound / Reputation Tokens"],
+];
+
+const wardleyNameMap = {};
+wardleySolutions.forEach(s => { wardleyNameMap[s.name] = s; });
+
+function initWardley() { renderWardley(); }
+
+function renderWardley() {
+  const pane = document.getElementById('pane-wardley');
+  const svgEl = document.getElementById('wardley-map');
+  const tip = document.getElementById('wardley-tip');
+  const W = pane.clientWidth, H = pane.clientHeight;
+  svgEl.setAttribute('viewBox', `0 0 ${W} ${H}`);
+
+  const margin = { top: 100, right: 40, bottom: 60, left: 72 };
+  const pw = W - margin.left - margin.right;
+  const ph = H - margin.top - margin.bottom;
+  const sx = ex => margin.left + ((ex - 1) / 4) * pw;
+  const sy = vc => margin.top + (1 - vc) * ph;
+
+  let out = '';
+  out += `<defs>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%"><feGaussianBlur stdDeviation="6" result="blur"/><feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="softglow" x="-50%" y="-50%" width="200%" height="200%"><feGaussianBlur stdDeviation="3" result="blur"/><feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  </defs>`;
+
+  // Contour lines
+  const cx0 = sx(3), cy0 = sy(0.65);
+  for (let i = 1; i <= 8; i++) {
+    out += `<ellipse cx="${cx0}" cy="${cy0}" rx="${i*pw*0.065}" ry="${i*ph*0.055}" fill="none" stroke="#1a2029" stroke-width="0.5" stroke-opacity="${0.6-i*0.06}" />`;
+  }
+
+  // Evolution zones
+  [{ x0:1,x1:2,f:'rgba(248,81,73,0.06)' },{ x0:2,x1:3,f:'rgba(210,168,255,0.05)' },{ x0:3,x1:4,f:'rgba(121,192,255,0.04)' },{ x0:4,x1:5,f:'rgba(126,231,135,0.04)' }].forEach(z => {
+    out += `<rect x="${sx(z.x0)}" y="${margin.top}" width="${sx(z.x1)-sx(z.x0)}" height="${ph}" fill="${z.f}" />`;
+  });
+
+  // Grid
+  for (let i=2;i<=4;i++) out += `<line x1="${sx(i)}" y1="${margin.top}" x2="${sx(i)}" y2="${margin.top+ph}" stroke="#1e2836" stroke-width="1" stroke-dasharray="2,6" />`;
+  for (let v=0;v<=1.01;v+=0.1) out += `<line x1="${margin.left}" y1="${sy(v)}" x2="${margin.left+pw}" y2="${sy(v)}" stroke="#151c24" stroke-width="0.5" stroke-dasharray="1,8" />`;
+  out += `<rect x="${margin.left}" y="${margin.top}" width="${pw}" height="${ph}" fill="none" stroke="#1e2836" stroke-width="1" />`;
+
+  // Stage labels
+  [{x:1.5,t:'I · Genesis',s:'novel / rare'},{x:2.5,t:'II · Custom',s:'emerging / chaotic'},{x:3.5,t:'III · Product',s:'growing / stable'},{x:4.5,t:'IV · Commodity',s:'industrialised'}].forEach(l => {
+    out += `<text x="${sx(l.x)}" y="${margin.top+ph+22}" text-anchor="middle" fill="#5a6a7a" font-size="10" font-family="JetBrains Mono" font-weight="400" letter-spacing="0.04em">${l.t}</text>`;
+    out += `<text x="${sx(l.x)}" y="${margin.top+ph+36}" text-anchor="middle" fill="#3d4a58" font-size="8.5" font-family="JetBrains Mono" font-weight="300">${l.s}</text>`;
+  });
+  out += `<text x="${margin.left+pw/2}" y="${H-8}" text-anchor="middle" fill="#3d4a58" font-size="8.5" font-family="JetBrains Mono" font-weight="300" letter-spacing="0.12em">EVOLUTION ───────→</text>`;
+
+  // Y-axis
+  [{v:0.92,t:'VISIBLE'},{v:0.78,t:'participant-facing'},{v:0.55,t:'enabling'},{v:0.30,t:'infrastructure'},{v:0.06,t:'INVISIBLE'}].forEach(l => {
+    const e = l.t==='VISIBLE'||l.t==='INVISIBLE';
+    out += `<text x="${margin.left-10}" y="${sy(l.v)+3}" text-anchor="end" fill="${e?'#3d4a58':'#4a5568'}" font-size="${e?'7.5':'8.5'}" font-family="JetBrains Mono" font-weight="${e?'300':'400'}" letter-spacing="${e?'0.15em':'0.04em'}">${l.t}</text>`;
+  });
+  out += `<text x="16" y="${margin.top+ph/2}" text-anchor="middle" fill="#3d4a58" font-size="8.5" font-family="JetBrains Mono" font-weight="300" letter-spacing="0.12em" transform="rotate(-90 16 ${margin.top+ph/2})">VALUE CHAIN ───────→</text>`;
+
+  // Dependency lines
+  wardleyDeps.forEach(([from,to]) => {
+    const a=wardleyNameMap[from], b=wardleyNameMap[to];
+    if(!a||!b) return;
+    out += `<line class="wdep" data-from="${from}" data-to="${to}" x1="${sx(a.ex)}" y1="${sy(a.vc)}" x2="${sx(b.ex)}" y2="${sy(b.vc)}" stroke="#2a3544" stroke-width="1" stroke-opacity="0.35" />`;
+  });
+
+  // Nodes
+  wardleySolutions.forEach((s,i) => {
+    const cx=sx(s.ex), cy=sy(s.vc), r=s.mentions*3+5, color=wardleyCatColors[s.cat];
+    const delay=(i*0.04).toFixed(2);
+    out += `<g class="node-g wnode-g" data-idx="${i}" style="animation-delay:${delay}s;transform-origin:${cx}px ${cy}px">`;
+    out += `<circle cx="${cx}" cy="${cy}" r="${r+4}" fill="none" stroke="${color}" stroke-width="0.5" stroke-opacity="0.15" />`;
+    out += `<circle class="wnode-circle" cx="${cx}" cy="${cy}" r="${r}" fill="${color}" fill-opacity="0.75" stroke="${color}" stroke-width="1.5" stroke-opacity="0.25" style="cursor:pointer;transition:fill-opacity 0.15s" />`;
+    out += `<circle cx="${cx-r*0.25}" cy="${cy-r*0.25}" r="${r*0.2}" fill="white" fill-opacity="0.12" />`;
+
+    let lx, la;
+    if (cx > margin.left+pw*0.82) { lx=cx-r-8; la='end'; } else { lx=cx+r+8; la='start'; }
+    const labelText=s.name;
+    if (labelText.length > 22) {
+      const mid=Math.floor(labelText.length/2);
+      const sa=labelText.indexOf(' ',mid), sb=labelText.lastIndexOf(' ',mid);
+      const splitAt=(mid-sb<sa-mid)?sb:sa;
+      if(splitAt>0){
+        [labelText.substring(0,splitAt),labelText.substring(splitAt+1)].forEach((p,pi) => {
+          out += `<text class="wnode-label" data-idx="${i}" x="${lx}" y="${cy+4+pi*13-6}" text-anchor="${la}" fill="#b8c4d0" fill-opacity="0.9" font-size="10" font-family="JetBrains Mono" font-weight="400" style="pointer-events:none;transition:fill-opacity 0.15s">${p}</text>`;
+        });
+      } else {
+        out += `<text class="wnode-label" data-idx="${i}" x="${lx}" y="${cy+4}" text-anchor="${la}" fill="#b8c4d0" fill-opacity="0.9" font-size="10" font-family="JetBrains Mono" font-weight="400" style="pointer-events:none;transition:fill-opacity 0.15s">${labelText}</text>`;
+      }
+    } else {
+      const lines = labelText.split(' / ');
+      if(lines.length>1){
+        lines.forEach((line,li) => {
+          out += `<text class="wnode-label" data-idx="${i}" x="${lx}" y="${cy+4+li*13-(lines.length-1)*6}" text-anchor="${la}" fill="#b8c4d0" fill-opacity="0.9" font-size="10" font-family="JetBrains Mono" font-weight="400" style="pointer-events:none;transition:fill-opacity 0.15s">${line.trim()}</text>`;
+        });
+      } else {
+        out += `<text class="wnode-label" data-idx="${i}" x="${lx}" y="${cy+4}" text-anchor="${la}" fill="#b8c4d0" fill-opacity="0.9" font-size="10" font-family="JetBrains Mono" font-weight="400" style="pointer-events:none;transition:fill-opacity 0.15s">${labelText}</text>`;
+      }
+    }
+    out += `</g>`;
+  });
+
+  svgEl.innerHTML = out;
+
+  // Interactions
+  const nodeGroups = svgEl.querySelectorAll('.wnode-g');
+  const allCircles = svgEl.querySelectorAll('.wnode-circle');
+  const allLabels = svgEl.querySelectorAll('.wnode-label');
+  const allDeps = svgEl.querySelectorAll('.wdep');
+
+  nodeGroups.forEach(g => {
+    const circle = g.querySelector('.wnode-circle');
+    if(!circle) return;
+    const idx = parseInt(g.dataset.idx);
+    const s = wardleySolutions[idx];
+    const color = wardleyCatColors[s.cat];
+
+    const onEnter = (e) => {
+      const connected = new Set();
+      wardleyDeps.forEach(([from,to]) => { if(from===s.name) connected.add(to); if(to===s.name) connected.add(from); });
+      const connectedIdx = new Set();
+      wardleySolutions.forEach((o,oi) => { if(connected.has(o.name)) connectedIdx.add(oi); });
+
+      allCircles.forEach(c => { c.setAttribute('fill-opacity','0.08'); c.setAttribute('stroke-opacity','0.03'); });
+      allLabels.forEach(l => { l.setAttribute('fill-opacity','0.08'); });
+      allDeps.forEach(d => { d.setAttribute('stroke-opacity','0.04'); });
+      nodeGroups.forEach(ng => { const ring=ng.querySelectorAll('circle')[0]; if(ring) ring.setAttribute('stroke-opacity','0.02'); });
+
+      circle.setAttribute('fill-opacity','1'); circle.setAttribute('stroke-opacity','0.6');
+      circle.setAttribute('r', (s.mentions*3+5)*1.25); circle.setAttribute('filter','url(#glow)');
+      g.querySelectorAll('circle')[0].setAttribute('stroke-opacity','0.4');
+      svgEl.querySelectorAll(`.wnode-label[data-idx="${idx}"]`).forEach(l => { l.setAttribute('fill-opacity','1'); l.setAttribute('fill','#e2e8f0'); });
+
+      connectedIdx.forEach(ci => {
+        const cg=svgEl.querySelector(`.wnode-g[data-idx="${ci}"]`);
+        if(cg){ const cc=cg.querySelector('.wnode-circle'); if(cc){cc.setAttribute('fill-opacity','0.55');cc.setAttribute('stroke-opacity','0.2');cc.setAttribute('filter','url(#softglow)');} cg.querySelectorAll('circle')[0].setAttribute('stroke-opacity','0.1'); }
+        svgEl.querySelectorAll(`.wnode-label[data-idx="${ci}"]`).forEach(l=>l.setAttribute('fill-opacity','0.65'));
+      });
+
+      allDeps.forEach(d => {
+        if(d.dataset.from===s.name||d.dataset.to===s.name){d.setAttribute('stroke',color);d.setAttribute('stroke-opacity','0.7');d.setAttribute('stroke-width','1.5');}
+      });
+
+      tip.innerHTML = `<div class="tt-name">${s.name}</div><div class="tt-cat" style="color:${color}">${s.cat}</div><div class="tt-tags">${s.problems.map(p=>`<span class="tt-tag">${p}</span>`).join('')}</div><div class="tt-section"><b>Actors:</b> ${s.actors.join(', ')}</div><div class="tt-section" style="font-style:italic">${s.examples}</div><div class="tt-mentions">${s.mentions} participant mention${s.mentions>1?'s':''}</div>`;
+      tip.style.opacity='1';
+    };
+
+    const onMove = (e) => {
+      let left=e.clientX+18, top=e.clientY-12;
+      if(left+300>W) left=e.clientX-310;
+      if(top+200>H) top=e.clientY-200;
+      tip.style.left=left+'px'; tip.style.top=top+'px';
+    };
+
+    const onLeave = () => {
+      allCircles.forEach((c,ci) => { c.setAttribute('fill-opacity','0.75'); c.setAttribute('stroke-opacity','0.25'); c.setAttribute('r',wardleySolutions[ci].mentions*3+5); c.removeAttribute('filter'); });
+      allLabels.forEach(l => { l.setAttribute('fill-opacity','0.9'); l.setAttribute('fill','#b8c4d0'); });
+      allDeps.forEach(d => { d.setAttribute('stroke','#2a3544'); d.setAttribute('stroke-opacity','0.35'); d.setAttribute('stroke-width','1'); });
+      nodeGroups.forEach(ng => { const ring=ng.querySelectorAll('circle')[0]; if(ring) ring.setAttribute('stroke-opacity','0.15'); });
+      tip.style.opacity='0';
+    };
+
+    circle.addEventListener('mouseenter', onEnter);
+    circle.addEventListener('mousemove', onMove);
+    circle.addEventListener('mouseleave', onLeave);
+    g.querySelectorAll('.wnode-label').forEach(l => { l.style.pointerEvents='auto'; l.style.cursor='pointer'; l.addEventListener('mouseenter',onEnter); l.addEventListener('mousemove',onMove); l.addEventListener('mouseleave',onLeave); });
+  });
+
+  // Legend
+  const legendEl = document.getElementById('wardley-legend');
+  if(legendEl.children.length === 0) {
+    const categories = [...new Set(wardleySolutions.map(s=>s.cat))];
+    let activeFilter = null;
+    categories.forEach(cat => {
+      const item = document.createElement('div'); item.className = 'lg';
+      item.innerHTML = `<div class="sw" style="background:${wardleyCatColors[cat]}"></div>${cat}`;
+      item.addEventListener('click', () => {
+        if(activeFilter===cat){
+          activeFilter=null;
+          document.querySelectorAll('#wardley-legend .lg').forEach(l=>l.classList.remove('dimmed'));
+          allCircles.forEach(c=>{c.setAttribute('fill-opacity','0.75');c.setAttribute('stroke-opacity','0.25');});
+          allLabels.forEach(l=>l.setAttribute('fill-opacity','0.9'));
+          allDeps.forEach(d=>d.setAttribute('stroke-opacity','0.35'));
+          nodeGroups.forEach(ng=>{ng.querySelectorAll('circle')[0].setAttribute('stroke-opacity','0.15');});
+        } else {
+          activeFilter=cat;
+          document.querySelectorAll('#wardley-legend .lg').forEach(l=>{l.classList.toggle('dimmed',!l.textContent.includes(cat));});
+          wardleySolutions.forEach((s,i) => {
+            const match=s.cat===cat;
+            const c=allCircles[i]; if(c){c.setAttribute('fill-opacity',match?'0.9':'0.06');c.setAttribute('stroke-opacity',match?'0.4':'0.02');}
+            svgEl.querySelectorAll(`.wnode-label[data-idx="${i}"]`).forEach(l=>{l.setAttribute('fill-opacity',match?'1':'0.06');});
+            const ng=svgEl.querySelector(`.wnode-g[data-idx="${i}"]`); if(ng) ng.querySelectorAll('circle')[0].setAttribute('stroke-opacity',match?'0.2':'0.02');
+          });
+          allDeps.forEach(d=>{
+            const fc=wardleyNameMap[d.dataset.from]?.cat, tc=wardleyNameMap[d.dataset.to]?.cat;
+            d.setAttribute('stroke-opacity',(fc===cat||tc===cat)?'0.4':'0.03');
+          });
+        }
+      });
+      legendEl.appendChild(item);
+    });
+  }
+}
+
+// ======================== ACTORS TAB ========================
+function initActors() {
+  const container = document.getElementById('actors-container');
+  const W = container.clientWidth, H = container.clientHeight;
+
+  const cats = { infra:'#f85149', reputation:'#ffa657', sense:'#d2a8ff', finance:'#79c0ff', security:'#7ee787', research:'#ff7b72', service:'#8b949e' };
+  const nodes = [
+    {id:'Metagov',cat:'infra',desc:'Constitutional design, KOI, RIDs, Interop program',size:18,mentioned:6},
+    {id:'Aragon',cat:'infra',desc:'DAO tooling, governance frameworks',size:12,mentioned:2},
+    {id:'Tally',cat:'infra',desc:'Proposal tracking, governance dashboards',size:10,mentioned:2},
+    {id:'Agora',cat:'infra',desc:'Governance hub for proposal review/voting',size:8,mentioned:1},
+    {id:'Scroll DAO',cat:'infra',desc:'Delegate accelerator, phased governance, co-creation',size:12,mentioned:3},
+    {id:'DeepDAO',cat:'reputation',desc:'Contribution tracking, reputation systems',size:10,mentioned:2},
+    {id:'Forward',cat:'reputation',desc:'Delegate programs, reputation frameworks',size:9,mentioned:1},
+    {id:'Kokonut Network',cat:'reputation',desc:'Merit-based governance',size:8,mentioned:1},
+    {id:'Wasabi',cat:'reputation',desc:'Soulbound tokens, rage quit mechanics',size:8,mentioned:1},
+    {id:'Hats Protocol',cat:'reputation',desc:'Role-based access, merit governance',size:8,mentioned:1},
+    {id:'Polis',cat:'sense',desc:'Opinion clustering, collective intelligence',size:11,mentioned:2},
+    {id:'Lighthouse',cat:'sense',desc:'Signals protocol — values, not votes',size:9,mentioned:1},
+    {id:'Mission Public',cat:'sense',desc:'Deliberation experiments (Cosmos)',size:9,mentioned:1},
+    {id:'NewPublic',cat:'sense',desc:'Community coordination tools',size:8,mentioned:1},
+    {id:'Karpatkey',cat:'finance',desc:'Treasury management, DeFi strategies',size:9,mentioned:1},
+    {id:'Steakhouse',cat:'finance',desc:'Financial reporting, analytics',size:8,mentioned:1},
+    {id:'a16z',cat:'finance',desc:'Network token framework, "end of foundations"',size:11,mentioned:2},
+    {id:'ENS Labs',cat:'security',desc:'Universal resolver, security infra, veto.ensdao.eth',size:12,mentioned:3},
+    {id:'VERP',cat:'security',desc:'Biometric identity + sensor networks',size:9,mentioned:1},
+    {id:'Immunefi',cat:'security',desc:'Bug bounties, vulnerability disclosure',size:8,mentioned:1},
+    {id:'immediacy.ai',cat:'security',desc:'AI-powered sim-juries, programmatic ethics',size:9,mentioned:1},
+    {id:'Othman (GMS)',cat:'research',desc:'Governance Memory System — 5-layer framework',size:11,mentioned:1},
+    {id:'Durgadas',cat:'research',desc:'Tensegrity, Prevolution, social architecture',size:10,mentioned:1},
+    {id:'Regis Chapman',cat:'research',desc:'Beyond game theory, paradox navigation',size:9,mentioned:1},
+    {id:'Ellie Rennie',cat:'research',desc:'Ethnographic governance research, Telescope bot',size:9,mentioned:1},
+    {id:'accessor.eth',cat:'research',desc:'ENS governance maximalism, security research',size:10,mentioned:1},
+    {id:'SeedGov',cat:'service',desc:'Professional delegate services',size:8,mentioned:1},
+    {id:'Curialab',cat:'service',desc:'Professional delegate services',size:8,mentioned:1},
+    {id:'L2Beat',cat:'service',desc:'Decentralization metrics, delegate services',size:9,mentioned:2},
+    {id:'anode.gg',cat:'service',desc:'Governance tooling',size:7,mentioned:1},
+  ];
+  const links = [
+    {source:'Metagov',target:'Aragon',v:3},{source:'Metagov',target:'Polis',v:3},{source:'Metagov',target:'Mission Public',v:2},
+    {source:'Metagov',target:'Othman (GMS)',v:4},{source:'Metagov',target:'Ellie Rennie',v:3},{source:'Metagov',target:'Durgadas',v:2},
+    {source:'Metagov',target:'Scroll DAO',v:2},{source:'Metagov',target:'Lighthouse',v:2},
+    {source:'DeepDAO',target:'Forward',v:3},{source:'DeepDAO',target:'Kokonut Network',v:2},
+    {source:'Kokonut Network',target:'Wasabi',v:3},{source:'Wasabi',target:'Hats Protocol',v:3},
+    {source:'Hats Protocol',target:'Kokonut Network',v:2},{source:'Forward',target:'Scroll DAO',v:2},
+    {source:'Polis',target:'Lighthouse',v:3},{source:'Polis',target:'NewPublic',v:2},
+    {source:'Mission Public',target:'Polis',v:2},{source:'Lighthouse',target:'NewPublic',v:2},
+    {source:'Karpatkey',target:'Steakhouse',v:3},{source:'a16z',target:'Karpatkey',v:2},
+    {source:'Tally',target:'Karpatkey',v:2},{source:'Tally',target:'Agora',v:3},
+    {source:'ENS Labs',target:'accessor.eth',v:4},{source:'ENS Labs',target:'Immunefi',v:2},
+    {source:'VERP',target:'ENS Labs',v:1},{source:'immediacy.ai',target:'Durgadas',v:1},
+    {source:'Othman (GMS)',target:'Ellie Rennie',v:2},{source:'Durgadas',target:'Regis Chapman',v:3},
+    {source:'Othman (GMS)',target:'Durgadas',v:2},{source:'Regis Chapman',target:'Metagov',v:1},
+    {source:'accessor.eth',target:'Scroll DAO',v:1},
+    {source:'SeedGov',target:'Curialab',v:3},{source:'SeedGov',target:'L2Beat',v:2},
+    {source:'Curialab',target:'L2Beat',v:2},{source:'L2Beat',target:'Scroll DAO',v:2},
+    {source:'L2Beat',target:'Tally',v:2},
+    {source:'Scroll DAO',target:'DeepDAO',v:2},{source:'Aragon',target:'Hats Protocol',v:2},
+    {source:'a16z',target:'ENS Labs',v:2},{source:'Scroll DAO',target:'Karpatkey',v:1},
+    {source:'Metagov',target:'NewPublic',v:2},
+  ];
+
+  const svg = d3.select(container).append('svg').attr('width', W).attr('height', H);
+  const tip = d3.select('#actors-tip');
+  const catNames = { infra:'Governance Infra', reputation:'Reputation & Identity', sense:'Sensemaking', finance:'Financial', security:'Security & Verification', research:'Research & Frameworks', service:'Service Provider' };
+
+  const simulation = d3.forceSimulation(nodes)
+    .force('link', d3.forceLink(links).id(d=>d.id).distance(d=>100-d.v*10).strength(d=>d.v*0.08))
+    .force('charge', d3.forceManyBody().strength(-250))
+    .force('center', d3.forceCenter(W/2, H/2))
+    .force('collision', d3.forceCollide().radius(d=>d.size+8))
+    .force('x', d3.forceX(W/2).strength(0.03))
+    .force('y', d3.forceY(H/2).strength(0.03));
+
+  window._actorsSim = simulation;
+
+  const link = svg.append('g').selectAll('line').data(links).join('line')
+    .attr('stroke','#21262d').attr('stroke-width',d=>d.v*0.8).attr('stroke-opacity',0.6);
+
+  const node = svg.append('g').selectAll('g').data(nodes).join('g')
+    .call(d3.drag()
+      .on('start',(e,d)=>{if(!e.active)simulation.alphaTarget(0.3).restart();d.fx=d.x;d.fy=d.y;})
+      .on('drag',(e,d)=>{d.fx=e.x;d.fy=e.y;})
+      .on('end',(e,d)=>{if(!e.active)simulation.alphaTarget(0);d.fx=null;d.fy=null;})
+    );
+
+  node.append('circle').attr('r',d=>d.size).attr('fill',d=>cats[d.cat]).attr('fill-opacity',0.85).attr('stroke','#0d1117').attr('stroke-width',1.5);
+  node.append('text').text(d=>d.id).attr('dy',d=>d.size+14).attr('text-anchor','middle').attr('fill','#c9d1d9').attr('font-size','11px').attr('font-family','JetBrains Mono, monospace');
+
+  node.on('mouseover',(e,d)=>{
+    const connected=new Set();
+    links.forEach(l=>{const s=typeof l.source==='object'?l.source.id:l.source;const t=typeof l.target==='object'?l.target.id:l.target;if(s===d.id)connected.add(t);if(t===d.id)connected.add(s);});
+    node.select('circle').attr('fill-opacity',n=>n.id===d.id||connected.has(n.id)?1:0.15);
+    node.select('text').attr('fill-opacity',n=>n.id===d.id||connected.has(n.id)?1:0.15);
+    link.attr('stroke-opacity',l=>{const s=typeof l.source==='object'?l.source.id:l.source;const t=typeof l.target==='object'?l.target.id:l.target;return s===d.id||t===d.id?0.8:0.05;})
+        .attr('stroke',l=>{const s=typeof l.source==='object'?l.source.id:l.source;const t=typeof l.target==='object'?l.target.id:l.target;return s===d.id||t===d.id?'#484f58':'#21262d';});
+    tip.html('<b>'+d.id+'</b><br><span class="cat">'+catNames[d.cat]+'</span><br><br>'+d.desc+'<br><br>Mentioned by '+d.mentioned+' participant'+(d.mentioned>1?'s':'')+'<br>Connected to '+connected.size+' other actors')
+      .style('opacity',1).style('left',(e.pageX+14)+'px').style('top',(e.pageY-14)+'px');
+  }).on('mousemove',(e)=>{
+    tip.style('left',(e.pageX+14)+'px').style('top',(e.pageY-14)+'px');
+  }).on('mouseout',()=>{
+    node.select('circle').attr('fill-opacity',0.85);
+    node.select('text').attr('fill-opacity',1);
+    link.attr('stroke-opacity',0.6).attr('stroke','#21262d');
+    tip.style('opacity',0);
+  });
+
+  simulation.on('tick',()=>{
+    link.attr('x1',d=>d.source.x).attr('y1',d=>d.source.y).attr('x2',d=>d.target.x).attr('y2',d=>d.target.y);
+    node.attr('transform',d=>'translate('+d.x+','+d.y+')');
+  });
+}
+
+// ======================== SANKEY TAB ========================
+function initSankey() {
+  const labels = [
+    "Token Voting Failure","Broken Contributor Economies","Governance Theater","Institutional Amnesia",
+    "Informal Power Dynamics","Over-Reliance on Game Theory","Lack of Clear Purpose","Technical & Legal Gaps",
+    "Reputation & Merit Systems","AI-Augmented Governance","Deliberation & Signaling","Governance Memory Systems",
+    "Structural & Constitutional","Compensation Innovation","Security & Verification","Alternative Gov Models",
+    "Metagov","DeepDAO","Scroll DAO","Polis","immediacy.ai","Mission Public","Aragon","Tally",
+    "Karpatkey","a16z","Forward","ENS Labs","Othman (GMS)","Durgadas","Lighthouse","VERP","Kokonut Network","Public AI Network",
+  ];
+  const allLinks = [
+    [0,8,5],[0,10,4],[0,9,3],[0,12,2],
+    [1,13,5],[1,8,3],[1,12,2],
+    [2,12,4],[2,15,3],[2,10,2],
+    [3,11,5],[3,9,2],
+    [4,10,4],[4,8,3],[4,11,2],
+    [5,12,4],[5,10,3],[5,15,2],
+    [6,15,4],[6,12,3],
+    [7,14,5],[7,9,2],
+    [8,17,3],[8,26,3],[8,32,2],[8,18,2],
+    [9,20,3],[9,27,2],
+    [10,19,4],[10,30,3],[10,21,3],[10,16,2],
+    [11,28,4],[11,16,3],
+    [12,29,4],[12,22,3],[12,16,3],[12,18,2],
+    [13,24,3],[13,25,3],[13,23,2],
+    [14,27,3],[14,31,3],
+    [15,33,3],[15,16,2],[15,22,2],
+  ];
+  const nodeColors = labels.map((_,i)=>{
+    if(i<=7)return 'rgba(248,81,73,0.85)';
+    if(i<=15)return 'rgba(126,231,135,0.85)';
+    return 'rgba(121,184,255,0.85)';
+  });
+  const linkColors = allLinks.map(l=>l[0]<=7?'rgba(248,81,73,0.15)':'rgba(126,231,135,0.15)');
+
+  Plotly.newPlot('sankey-chart', [{
+    type:'sankey', orientation:'h', arrangement:'snap',
+    node:{ pad:20, thickness:24, line:{color:'#0d1117',width:1}, label:labels, color:nodeColors, hovertemplate:'%{label}<extra></extra>' },
+    link:{ source:allLinks.map(l=>l[0]), target:allLinks.map(l=>l[1]), value:allLinks.map(l=>l[2]), color:linkColors, hovertemplate:'%{source.label} → %{target.label}<extra></extra>' },
+  }], {
+    paper_bgcolor:'#0d1117', plot_bgcolor:'#0d1117',
+    font:{ color:'#c9d1d9', size:12, family:'JetBrains Mono, monospace' },
+    margin:{l:20,r:20,t:10,b:10},
+  }, { responsive:true, displayModeBar:false });
+}
+
+// Handle resize
+window.addEventListener('resize', () => {
+  const activeTab = document.querySelector('.tab.active')?.dataset.tab;
+  if (activeTab === 'urgency' && initialized.urgency) Plotly.Plots.resize('urgency-chart');
+  if (activeTab === 'sankey' && initialized.sankey) Plotly.Plots.resize('sankey-chart');
+  if (activeTab === 'wardley' && initialized.wardley) renderWardley();
+});
+</script>
+</body>
+</html>

--- a/phase1/problems.html
+++ b/phase1/problems.html
@@ -1,0 +1,527 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>gov/acc — Problems Map</title>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,500;0,9..144,700;1,9..144,300&family=JetBrains+Mono:wght@300;400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #131920;
+    --border: #1e2836;
+    --text: #b8c4d0;
+    --text-dim: #5a6a7a;
+    --text-bright: #e8edf3;
+    --accent: #7ee787;
+    --critical: #f85149;
+    --high: #ffa657;
+    --medium: #ffd866;
+    --lower: #7ee787;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'JetBrains Mono', monospace;
+    min-height: 100vh;
+    overflow-x: hidden;
+  }
+
+  /* Noise texture */
+  body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.025'/%3E%3C/svg%3E");
+    pointer-events: none;
+    z-index: 999;
+  }
+
+  /* Header */
+  .header {
+    padding: 28px 32px 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+  .header h1 {
+    font-family: 'Fraunces', serif;
+    font-size: 1.6em;
+    font-weight: 500;
+    color: var(--text-bright);
+    letter-spacing: -0.03em;
+    line-height: 1.1;
+    font-optical-sizing: auto;
+  }
+  .header h1 em { color: var(--critical); font-style: italic; font-weight: 300; }
+  .header .meta {
+    text-align: right;
+    font-size: 0.65em;
+    color: var(--text-dim);
+    font-weight: 300;
+    line-height: 1.7;
+  }
+  .header .meta strong { color: var(--text); font-weight: 500; }
+  .subtitle {
+    padding: 6px 32px 0;
+    font-size: 0.72em;
+    color: var(--text-dim);
+    font-weight: 300;
+    max-width: 680px;
+    line-height: 1.6;
+  }
+
+  /* Urgency scale */
+  .urgency-scale {
+    display: flex;
+    gap: 16px;
+    padding: 16px 32px 12px;
+    font-size: 0.62em;
+    color: var(--text-dim);
+    font-weight: 400;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .urgency-scale .us-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+  .urgency-scale .us-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+
+  /* Grid of problem cards */
+  .problems-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 2px;
+    padding: 0 32px 32px;
+  }
+
+  @media (max-width: 1100px) {
+    .problems-grid { grid-template-columns: 1fr; }
+  }
+
+  /* Problem card */
+  .problem-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 20px 24px;
+    position: relative;
+    overflow: hidden;
+    transition: border-color 0.2s, background 0.2s;
+  }
+  .problem-card:hover {
+    border-color: var(--severity-color);
+    background: #151c25;
+  }
+
+  /* Severity stripe */
+  .problem-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 3px;
+    height: 100%;
+    background: var(--severity-color);
+    opacity: 0.7;
+  }
+
+  /* Top row */
+  .pc-top {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+  .pc-rank {
+    font-family: 'Fraunces', serif;
+    font-size: 2em;
+    font-weight: 700;
+    color: var(--severity-color);
+    line-height: 1;
+    opacity: 0.3;
+    flex-shrink: 0;
+    min-width: 36px;
+    text-align: right;
+  }
+  .pc-title-block { flex: 1; }
+  .pc-title {
+    font-family: 'Fraunces', serif;
+    font-size: 1.15em;
+    font-weight: 500;
+    color: var(--text-bright);
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+  }
+  .pc-severity {
+    display: inline-block;
+    font-size: 0.55em;
+    font-family: 'JetBrains Mono', monospace;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 2px 8px;
+    border-radius: 2px;
+    margin-top: 4px;
+    font-weight: 500;
+    background: color-mix(in srgb, var(--severity-color) 12%, transparent);
+    color: var(--severity-color);
+    border: 1px solid color-mix(in srgb, var(--severity-color) 25%, transparent);
+  }
+
+  /* Metrics row */
+  .pc-metrics {
+    display: flex;
+    gap: 20px;
+    margin-bottom: 14px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid #1a2029;
+  }
+  .pc-metric {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .pc-metric .val {
+    font-size: 1.4em;
+    font-weight: 500;
+    color: var(--text-bright);
+    line-height: 1;
+  }
+  .pc-metric .label {
+    font-size: 0.6em;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 300;
+  }
+
+  /* Breadth bar */
+  .breadth-bar {
+    display: flex;
+    gap: 3px;
+    margin-bottom: 14px;
+  }
+  .breadth-bar .seg {
+    height: 4px;
+    flex: 1;
+    border-radius: 1px;
+    background: #1a2029;
+    transition: background 0.3s;
+  }
+  .breadth-bar .seg.filled {
+    background: var(--severity-color);
+    opacity: 0.6;
+  }
+
+  /* Participants */
+  .pc-participants {
+    font-size: 0.68em;
+    color: var(--text-dim);
+    line-height: 1.6;
+    margin-bottom: 14px;
+    font-weight: 300;
+  }
+  .pc-participants b { color: var(--text); font-weight: 500; }
+  .pc-participants .name {
+    display: inline-block;
+    padding: 0 4px;
+    margin: 1px 0;
+    border-radius: 2px;
+    background: rgba(255,255,255,0.03);
+    border: 1px solid #1a2029;
+    color: var(--text);
+    font-weight: 400;
+  }
+
+  /* Solutions section */
+  .pc-solutions-header {
+    font-size: 0.58em;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 6px;
+    font-weight: 400;
+  }
+  .pc-solutions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+  .pc-sol {
+    font-size: 0.65em;
+    padding: 3px 8px;
+    border-radius: 2px;
+    background: rgba(126,231,135,0.06);
+    border: 1px solid rgba(126,231,135,0.12);
+    color: var(--accent);
+    font-weight: 400;
+    transition: background 0.15s, border-color 0.15s;
+    cursor: default;
+    position: relative;
+  }
+  .pc-sol:hover {
+    background: rgba(126,231,135,0.12);
+    border-color: rgba(126,231,135,0.25);
+  }
+  .pc-sol .sol-mentions {
+    color: var(--text-dim);
+    font-size: 0.88em;
+  }
+
+  /* Connections indicator */
+  .pc-connections {
+    margin-top: 10px;
+    font-size: 0.6em;
+    color: #3d4a58;
+    font-weight: 300;
+    font-style: italic;
+  }
+
+  /* Entry animation */
+  @keyframes slideUp {
+    from { opacity: 0; transform: translateY(16px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .problem-card {
+    animation: slideUp 0.5s ease-out both;
+  }
+
+  /* Footer */
+  .footer {
+    padding: 8px 32px 20px;
+    font-size: 0.58em;
+    color: #2a3544;
+    font-weight: 300;
+    text-align: center;
+    letter-spacing: 0.04em;
+  }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <div>
+    <h1>gov/acc — <em>Problems Map</em></h1>
+  </div>
+  <div class="meta">
+    Phase 1 Research<br>
+    <strong>19</strong> completed interviews<br>
+    Jan–Feb 2026
+  </div>
+</div>
+<div class="subtitle">10 governance problems identified across 19 structured interviews, ranked by composite urgency score (breadth × 60% + depth × 40%). Each card shows who raised it, how deeply it was discussed, and which proposed solutions address it.</div>
+
+<div class="urgency-scale">
+  <div class="us-item"><div class="us-dot" style="background:var(--critical)"></div> Critical</div>
+  <div class="us-item"><div class="us-dot" style="background:var(--high)"></div> High</div>
+  <div class="us-item"><div class="us-dot" style="background:var(--medium)"></div> Medium</div>
+  <div class="us-item"><div class="us-dot" style="background:var(--lower)"></div> Lower priority</div>
+</div>
+
+<div class="problems-grid" id="grid"></div>
+
+<div class="footer">gov/acc Phase 1 · Harmonica structured interview · Data from 19 completed conversations</div>
+
+<script>
+const problems = [
+  {
+    name: "Token Voting Failure & Plutocracy",
+    breadth: 12, depth: 4.2,
+    who: ["Eugene", "Zeugh", "Malachite", "Hima", "Marlene", "Alex Soto", "Trigs", "Raphael", "Artem", "Chris", "Regis", "Ivey"],
+  },
+  {
+    name: "Governance Theater & Recentralization",
+    breadth: 9, depth: 3.8,
+    who: ["Coffee-crusher", "Ivey", "Carl", "Alex Soto", "Marlene", "Chris", "Zeugh", "Hima", "Trigs"],
+  },
+  {
+    name: "Broken Contributor Economies",
+    breadth: 7, depth: 5.1,
+    who: ["Marlene", "Alex Soto", "Coffee-crusher", "Zeugh", "Raphael", "Malachite", "Chris"],
+  },
+  {
+    name: "Voting Fatigue & Apathy",
+    breadth: 8, depth: 2.8,
+    who: ["Eugene", "Martin", "Trigs", "Hima", "Raphael", "Zeugh", "Marlene", "Ivey"],
+  },
+  {
+    name: "Informal Power & Narrative Capture",
+    breadth: 6, depth: 3.5,
+    who: ["Othman", "Zeugh", "Marlene", "Alex Soto", "Trigs", "Hima"],
+  },
+  {
+    name: "Institutional Amnesia",
+    breadth: 5, depth: 5.8,
+    who: ["Othman", "Artem", "Eugene", "Regis", "Martin"],
+  },
+  {
+    name: "Delegate Sustainability",
+    breadth: 5, depth: 4.0,
+    who: ["Marlene", "Alex Soto", "Zeugh", "Malachite", "Coffee-crusher"],
+  },
+  {
+    name: "Lack of Clear Purpose",
+    breadth: 5, depth: 3.2,
+    who: ["Eugene", "Raphael", "Carl", "Coffee-crusher", "Ivey"],
+  },
+  {
+    name: "Over-Reliance on Game Theory",
+    breadth: 4, depth: 6.5,
+    who: ["Regis", "Martin", "Durgadas (via Regis)", "Artem"],
+  },
+  {
+    name: "Technical & Legal Gaps",
+    breadth: 4, depth: 4.8,
+    who: ["Della Foresta", "Jason C", "Joseph", "Hima"],
+  },
+];
+
+// Solution data with problem mappings
+const solutions = [
+  { name: "Conviction Voting", mentions: 5, problems: ["Token voting failure", "Voting fatigue", "Informal power"] },
+  { name: "Soulbound / Reputation Tokens", mentions: 6, problems: ["Token voting failure", "Broken contributor economies", "Informal power", "Delegate sustainability"] },
+  { name: "Delegate Verification", mentions: 4, problems: ["Token voting failure", "Delegate sustainability", "Informal power"] },
+  { name: "AI Governance Agents", mentions: 4, problems: ["Voting fatigue", "Token voting failure", "Institutional amnesia"] },
+  { name: "AI Dispute Resolution", mentions: 2, problems: ["Technical & legal gaps", "Over-reliance on game theory"] },
+  { name: "Polis / Opinion Clustering", mentions: 5, problems: ["Token voting failure", "Informal power", "Voting fatigue"] },
+  { name: "Signals Protocol", mentions: 3, problems: ["Token voting failure", "Voting fatigue", "Lack of clear purpose"] },
+  { name: "Co-creation Cycles", mentions: 4, problems: ["Governance theater", "Lack of clear purpose", "Token voting failure"] },
+  { name: "Governance Memory System", mentions: 3, problems: ["Institutional amnesia", "Over-reliance on game theory", "Governance theater"] },
+  { name: "Reference Identifiers (RIDs)", mentions: 2, problems: ["Institutional amnesia", "Informal power"] },
+  { name: "Telescope Bot", mentions: 1, problems: ["Institutional amnesia", "Informal power"] },
+  { name: "Tensegrity Governance", mentions: 3, problems: ["Over-reliance on game theory", "Governance theater", "Lack of clear purpose", "Informal power"] },
+  { name: "Optimistic Governance", mentions: 4, problems: ["Voting fatigue", "Governance theater"] },
+  { name: "Specialized Committees", mentions: 5, problems: ["Governance theater", "Lack of clear purpose", "Broken contributor economies"] },
+  { name: "Proto-DAOs / Gated Governance", mentions: 4, problems: ["Lack of clear purpose", "Token voting failure", "Governance theater"] },
+  { name: "Contributor Streams", mentions: 5, problems: ["Broken contributor economies", "Delegate sustainability"] },
+  { name: "RPGF", mentions: 4, problems: ["Broken contributor economies", "Delegate sustainability"] },
+  { name: "VE / Buyback Models", mentions: 3, problems: ["Token voting failure", "Governance theater"] },
+  { name: "VERP Protocol", mentions: 1, problems: ["Technical & legal gaps", "Token voting failure"] },
+  { name: "Platform Cooperatives", mentions: 2, problems: ["Governance theater", "Technical & legal gaps", "Lack of clear purpose"] },
+  { name: "Centralized Ops + DAO Oversight", mentions: 5, problems: ["Governance theater", "Lack of clear purpose", "Voting fatigue"] },
+];
+
+// Map problem names to matching keys (fuzzy)
+function matchProblem(solProblem, cardName) {
+  const sp = solProblem.toLowerCase();
+  const cn = cardName.toLowerCase();
+  if (cn.includes('token voting') && sp.includes('token voting')) return true;
+  if (cn.includes('governance theater') && sp.includes('governance theater')) return true;
+  if (cn.includes('contributor') && sp.includes('contributor')) return true;
+  if (cn.includes('voting fatigue') && sp.includes('voting fatigue')) return true;
+  if (cn.includes('informal power') && sp.includes('informal power')) return true;
+  if (cn.includes('institutional amnesia') && sp.includes('institutional amnesia')) return true;
+  if (cn.includes('delegate') && sp.includes('delegate')) return true;
+  if (cn.includes('clear purpose') && sp.includes('clear purpose')) return true;
+  if (cn.includes('game theory') && sp.includes('game theory')) return true;
+  if (cn.includes('technical') && sp.includes('technical')) return true;
+  if (cn.includes('legal') && sp.includes('legal')) return true;
+  return false;
+}
+
+// Score and rank
+const maxBreadth = 12;
+const maxDepth = 6.5;
+problems.forEach(p => {
+  p.score = (p.breadth / maxBreadth) * 0.6 + (p.depth / maxDepth) * 0.4;
+  if (p.score > 0.7) { p.severity = 'Critical'; p.color = 'var(--critical)'; }
+  else if (p.score > 0.5) { p.severity = 'High'; p.color = 'var(--high)'; }
+  else if (p.score > 0.35) { p.severity = 'Medium'; p.color = 'var(--medium)'; }
+  else { p.severity = 'Lower'; p.color = 'var(--lower)'; }
+
+  // Find solutions that address this problem
+  p.solutions = solutions
+    .filter(s => s.problems.some(sp => matchProblem(sp, p.name)))
+    .sort((a, b) => b.mentions - a.mentions);
+});
+
+problems.sort((a, b) => b.score - a.score);
+
+// Find co-occurrence: problems that share participants
+function getCoOccurrence(p) {
+  const pSet = new Set(p.who);
+  const coProblems = [];
+  problems.forEach(other => {
+    if (other.name === p.name) return;
+    const overlap = other.who.filter(w => pSet.has(w)).length;
+    if (overlap >= 3) coProblems.push({ name: other.name, overlap });
+  });
+  coProblems.sort((a, b) => b.overlap - a.overlap);
+  return coProblems.slice(0, 3);
+}
+
+// Render
+const grid = document.getElementById('grid');
+
+problems.forEach((p, i) => {
+  const card = document.createElement('div');
+  card.className = 'problem-card';
+  card.style.setProperty('--severity-color', p.color);
+  card.style.animationDelay = (i * 0.07) + 's';
+
+  const rank = String(i + 1).padStart(2, '0');
+
+  // Co-occurrence
+  const coProblems = getCoOccurrence(p);
+  const coText = coProblems.length > 0
+    ? 'Co-raised with: ' + coProblems.map(c => c.name + ' (' + c.overlap + ' shared)').join(' · ')
+    : '';
+
+  card.innerHTML = `
+    <div class="pc-top">
+      <div class="pc-rank">${rank}</div>
+      <div class="pc-title-block">
+        <div class="pc-title">${p.name}</div>
+        <div class="pc-severity">${p.severity}</div>
+      </div>
+    </div>
+
+    <div class="pc-metrics">
+      <div class="pc-metric">
+        <div class="val">${p.breadth}<span style="color:var(--text-dim);font-size:0.5em;font-weight:300">/19</span></div>
+        <div class="label">Breadth</div>
+      </div>
+      <div class="pc-metric">
+        <div class="val">${p.depth.toFixed(1)}</div>
+        <div class="label">Avg depth (msgs)</div>
+      </div>
+      <div class="pc-metric">
+        <div class="val">${p.solutions.length}</div>
+        <div class="label">Solutions proposed</div>
+      </div>
+      <div class="pc-metric">
+        <div class="val">${(p.score * 100).toFixed(0)}</div>
+        <div class="label">Urgency score</div>
+      </div>
+    </div>
+
+    <div class="breadth-bar">
+      ${Array.from({length: 19}, (_, j) => `<div class="seg ${j < p.breadth ? 'filled' : ''}"></div>`).join('')}
+    </div>
+
+    <div class="pc-participants">
+      <b>Raised by:</b> ${p.who.map(w => `<span class="name">${w}</span>`).join(' ')}
+    </div>
+
+    <div class="pc-solutions-header">Proposed solutions (${p.solutions.length})</div>
+    <div class="pc-solutions">
+      ${p.solutions.map(s => `<div class="pc-sol">${s.name} <span class="sol-mentions">${s.mentions}×</span></div>`).join('')}
+    </div>
+
+    ${coText ? `<div class="pc-connections">${coText}</div>` : ''}
+  `;
+
+  grid.appendChild(card);
+});
+</script>
+</body>
+</html>

--- a/phase1/sankey.html
+++ b/phase1/sankey.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>gov/acc Research — Problem → Solution → Actor</title>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+<style>
+  body { margin: 0; background: #0d1117; color: #c9d1d9; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  h1 { text-align: center; padding: 24px 0 0; font-size: 1.4em; font-weight: 500; }
+  h1 span { color: #7ee787; }
+  p.sub { text-align: center; color: #8b949e; font-size: 0.85em; margin: 4px 0 12px; }
+  #chart { width: 100%; height: calc(100vh - 80px); }
+</style>
+</head>
+<body>
+<h1>gov/acc Phase 1 — <span>Problems → Solutions → Actors</span></h1>
+<p class="sub">33 engaged · 19 completed · Harmonica structured interview · Jan–Feb 2026</p>
+<div id="chart"></div>
+<script>
+// Nodes: Problems (0-7), Solutions (8-15), Actors (16-33)
+const labels = [
+  // Problems (red/orange)
+  "Token Voting Failure",           // 0
+  "Broken Contributor Economies",   // 1
+  "Governance Theater",             // 2
+  "Institutional Amnesia",          // 3
+  "Informal Power Dynamics",        // 4
+  "Over-Reliance on Game Theory",   // 5
+  "Lack of Clear Purpose",          // 6
+  "Technical & Legal Gaps",         // 7
+
+  // Solutions (green/teal)
+  "Reputation & Merit Systems",     // 8
+  "AI-Augmented Governance",        // 9
+  "Deliberation & Signaling",       // 10
+  "Governance Memory Systems",      // 11
+  "Structural & Constitutional",    // 12
+  "Compensation Innovation",        // 13
+  "Security & Verification",        // 14
+  "Alternative Gov Models",         // 15
+
+  // Actors (blue/purple)
+  "Metagov",                        // 16
+  "DeepDAO",                        // 17
+  "Scroll DAO",                     // 18
+  "Polis",                          // 19
+  "immediacy.ai",                   // 20
+  "Mission Public",                 // 21
+  "Aragon",                         // 22
+  "Tally",                          // 23
+  "Karpatkey",                      // 24
+  "a16z",                           // 25
+  "Forward",                        // 26
+  "ENS Labs",                       // 27
+  "Othman (GMS)",                   // 28
+  "Durgadas",                       // 29
+  "Lighthouse",                     // 30
+  "VERP",                           // 31
+  "Kokonut Network",                // 32
+  "Public AI Network",              // 33
+];
+
+// Problem → Solution links
+// [source, target, value]
+const problemToSolution = [
+  // Token Voting Failure →
+  [0, 8, 5],   // Reputation & Merit
+  [0, 10, 4],  // Deliberation
+  [0, 9, 3],   // AI-Augmented
+  [0, 12, 2],  // Structural
+
+  // Broken Contributor Economies →
+  [1, 13, 5],  // Compensation Innovation
+  [1, 8, 3],   // Reputation & Merit
+  [1, 12, 2],  // Structural
+
+  // Governance Theater →
+  [2, 12, 4],  // Structural & Constitutional
+  [2, 15, 3],  // Alternative Gov Models
+  [2, 10, 2],  // Deliberation
+
+  // Institutional Amnesia →
+  [3, 11, 5],  // Governance Memory
+  [3, 9, 2],   // AI-Augmented
+
+  // Informal Power Dynamics →
+  [4, 10, 4],  // Deliberation
+  [4, 8, 3],   // Reputation & Merit
+  [4, 11, 2],  // Governance Memory
+
+  // Over-Reliance on Game Theory →
+  [5, 12, 4],  // Structural & Constitutional
+  [5, 10, 3],  // Deliberation
+  [5, 15, 2],  // Alternative Gov Models
+
+  // Lack of Clear Purpose →
+  [6, 15, 4],  // Alternative Gov Models
+  [6, 12, 3],  // Structural
+
+  // Technical & Legal Gaps →
+  [7, 14, 5],  // Security & Verification
+  [7, 9, 2],   // AI-Augmented
+];
+
+// Solution → Actor links
+const solutionToActor = [
+  // Reputation & Merit → actors
+  [8, 17, 3],   // DeepDAO
+  [8, 26, 3],   // Forward
+  [8, 32, 2],   // Kokonut Network
+  [8, 18, 2],   // Scroll DAO
+
+  // AI-Augmented → actors
+  [9, 20, 3],   // immediacy.ai
+  [9, 27, 2],   // ENS Labs
+
+  // Deliberation & Signaling → actors
+  [10, 19, 4],  // Polis
+  [10, 30, 3],  // Lighthouse
+  [10, 21, 3],  // Mission Public
+  [10, 16, 2],  // Metagov
+
+  // Governance Memory → actors
+  [11, 28, 4],  // Othman (GMS)
+  [11, 16, 3],  // Metagov
+
+  // Structural & Constitutional → actors
+  [12, 29, 4],  // Durgadas
+  [12, 22, 3],  // Aragon
+  [12, 16, 3],  // Metagov
+  [12, 18, 2],  // Scroll DAO
+
+  // Compensation Innovation → actors
+  [13, 24, 3],  // Karpatkey
+  [13, 25, 3],  // a16z
+  [13, 23, 2],  // Tally
+
+  // Security & Verification → actors
+  [14, 27, 3],  // ENS Labs
+  [14, 31, 3],  // VERP
+
+  // Alternative Gov Models → actors
+  [15, 33, 3],  // Public AI Network
+  [15, 16, 2],  // Metagov
+  [15, 22, 2],  // Aragon
+];
+
+const allLinks = [...problemToSolution, ...solutionToActor];
+
+const sources = allLinks.map(l => l[0]);
+const targets = allLinks.map(l => l[1]);
+const values  = allLinks.map(l => l[2]);
+
+// Colors
+const nodeColors = labels.map((_, i) => {
+  if (i <= 7) return 'rgba(248,81,73,0.85)';       // problems — red
+  if (i <= 15) return 'rgba(126,231,135,0.85)';     // solutions — green
+  return 'rgba(121,184,255,0.85)';                   // actors — blue
+});
+
+const linkColors = allLinks.map(l => {
+  if (l[0] <= 7) return 'rgba(248,81,73,0.15)';     // problem→solution
+  return 'rgba(126,231,135,0.15)';                   // solution→actor
+});
+
+Plotly.newPlot('chart', [{
+  type: 'sankey',
+  orientation: 'h',
+  arrangement: 'snap',
+  node: {
+    pad: 20,
+    thickness: 24,
+    line: { color: '#0d1117', width: 1 },
+    label: labels,
+    color: nodeColors,
+    hovertemplate: '%{label}<extra></extra>',
+  },
+  link: {
+    source: sources,
+    target: targets,
+    value: values,
+    color: linkColors,
+    hovertemplate: '%{source.label} → %{target.label}<extra></extra>',
+  }
+}], {
+  paper_bgcolor: '#0d1117',
+  plot_bgcolor: '#0d1117',
+  font: { color: '#c9d1d9', size: 12, family: '-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif' },
+  margin: { l: 20, r: 20, t: 10, b: 10 },
+}, {
+  responsive: true,
+  displayModeBar: false,
+});
+</script>
+</body>
+</html>

--- a/phase1/solutions-wardley.html
+++ b/phase1/solutions-wardley.html
@@ -1,0 +1,653 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>gov/acc — Solutions Wardley Map</title>
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@300;400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #131920;
+    --grid: #1a2029;
+    --grid-strong: #242d38;
+    --text: #b8c4d0;
+    --text-dim: #5a6a7a;
+    --text-bright: #e2e8f0;
+    --accent: #7ee787;
+    --genesis: rgba(248,81,73,0.06);
+    --custom: rgba(210,168,255,0.05);
+    --product: rgba(121,192,255,0.04);
+    --commodity: rgba(126,231,135,0.04);
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'IBM Plex Mono', monospace;
+    min-height: 100vh;
+    overflow: hidden;
+  }
+
+  /* Grain overlay */
+  body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
+    pointer-events: none;
+    z-index: 999;
+    opacity: 0.6;
+  }
+
+  /* Header */
+  .header {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 10;
+    padding: 20px 28px 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    pointer-events: none;
+  }
+  .header-left h1 {
+    font-family: 'Instrument Serif', serif;
+    font-size: 1.5em;
+    font-weight: 400;
+    color: var(--text-bright);
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+  }
+  .header-left h1 em {
+    color: var(--accent);
+    font-style: italic;
+  }
+  .header-left .subtitle {
+    font-size: 0.68em;
+    color: var(--text-dim);
+    margin-top: 4px;
+    font-weight: 300;
+    letter-spacing: 0.02em;
+    max-width: 480px;
+    line-height: 1.5;
+  }
+  .header-left .caveat {
+    font-size: 0.6em;
+    color: #3d4a58;
+    margin-top: 3px;
+    font-weight: 300;
+    font-style: italic;
+    max-width: 420px;
+    line-height: 1.4;
+  }
+  .header-right {
+    text-align: right;
+    font-size: 0.6em;
+    color: var(--text-dim);
+    font-weight: 300;
+    line-height: 1.6;
+    padding-top: 4px;
+  }
+  .header-right .coord {
+    color: #3d4a58;
+    font-size: 0.9em;
+  }
+
+  /* Map canvas */
+  .map-wrap {
+    position: absolute;
+    inset: 0;
+  }
+  svg#map {
+    width: 100%;
+    height: 100%;
+  }
+
+  /* Tooltip */
+  .tooltip {
+    position: fixed;
+    z-index: 50;
+    background: #161d26;
+    border: 1px solid #2a3544;
+    border-radius: 2px;
+    padding: 14px 16px;
+    font-size: 11px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.12s;
+    max-width: 290px;
+    line-height: 1.55;
+    box-shadow: 0 12px 40px rgba(0,0,0,0.6), 0 0 0 1px rgba(126,231,135,0.05);
+  }
+  .tooltip .tt-name {
+    font-family: 'Instrument Serif', serif;
+    font-size: 15px;
+    color: var(--text-bright);
+    margin-bottom: 2px;
+  }
+  .tooltip .tt-cat {
+    font-weight: 500;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 8px;
+  }
+  .tooltip .tt-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px;
+    margin: 6px 0;
+  }
+  .tooltip .tt-tag {
+    font-size: 9.5px;
+    padding: 1px 6px;
+    border: 1px solid #2a3544;
+    color: var(--text);
+    border-radius: 1px;
+    background: rgba(255,255,255,0.02);
+  }
+  .tooltip .tt-section {
+    color: var(--text-dim);
+    margin-top: 5px;
+  }
+  .tooltip .tt-section b {
+    color: var(--text);
+    font-weight: 500;
+  }
+  .tooltip .tt-mentions {
+    color: #3d4a58;
+    margin-top: 8px;
+    padding-top: 6px;
+    border-top: 1px solid #1e2836;
+    font-size: 10px;
+  }
+
+  /* Legend */
+  .legend-panel {
+    position: absolute;
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+    display: flex;
+    gap: 14px;
+    padding: 8px 16px;
+    background: rgba(13,17,23,0.85);
+    border: 1px solid #1e2836;
+    border-radius: 2px;
+    backdrop-filter: blur(8px);
+  }
+  .legend-panel .lg {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 9.5px;
+    color: var(--text-dim);
+    cursor: pointer;
+    transition: opacity 0.15s;
+    font-weight: 400;
+    white-space: nowrap;
+  }
+  .legend-panel .lg:hover { color: var(--text); }
+  .legend-panel .lg.dimmed { opacity: 0.15; }
+  .legend-panel .lg .sw {
+    width: 7px;
+    height: 7px;
+    border-radius: 1px;
+  }
+
+  /* Staggered entry animation */
+  @keyframes nodeIn {
+    from { opacity: 0; transform: scale(0.3); }
+    to { opacity: 1; transform: scale(1); }
+  }
+  .node-g {
+    animation: nodeIn 0.4s ease-out both;
+  }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <div class="header-left">
+    <h1>gov/acc — <em>Wardley Map</em></h1>
+    <div class="subtitle">21 governance solutions mapped by evolution stage &amp; value chain visibility. Bubble size = participant mentions.</div>
+    <div class="caveat">Y-axis placement is editorial — solutions positioned from invisible infrastructure to direct participant experience. X derived from participant-reported maturity.</div>
+  </div>
+  <div class="header-right">
+    Phase 1 Research<br>
+    <span class="coord">19 completed · Jan–Feb 2026</span>
+  </div>
+</div>
+
+<div class="map-wrap">
+  <svg id="map"></svg>
+</div>
+
+<div class="tooltip" id="tip"></div>
+<div class="legend-panel" id="legend"></div>
+
+<script>
+const solutions = [
+  { name: "Conviction Voting", ex: 3.5, vc: 0.88, mentions: 5, cat: "Voting Reform", problems: ["Token voting failure", "Voting fatigue", "Informal power"], actors: ["Various DAOs"], examples: "Weight votes by time held + participation history" },
+  { name: "Optimistic Governance", ex: 3.5, vc: 0.84, mentions: 4, cat: "Structural", problems: ["Voting fatigue", "Governance theater"], actors: ["Various L2s"], examples: "Proposals pass unless challenged" },
+  { name: "Polis / Opinion Clustering", ex: 4, vc: 0.82, mentions: 5, cat: "Sensemaking", problems: ["Token voting failure", "Informal power", "Voting fatigue"], actors: ["Polis", "Metagov"], examples: "Collective sensemaking through opinion mapping" },
+  { name: "Contributor Streams", ex: 3.5, vc: 0.78, mentions: 5, cat: "Financial", problems: ["Broken contributor economies", "Delegate sustainability"], actors: ["Scroll DAO", "Various DAOs"], examples: "Bounties → Project Grants → Core Contributor Streams" },
+  { name: "Centralized Ops + DAO Oversight", ex: 3.5, vc: 0.74, mentions: 5, cat: "Alternative", problems: ["Governance theater", "Lack of clear purpose", "Voting fatigue"], actors: ["a16z (concept)", "Various L2s"], examples: "Foundations run day-to-day; DAO approves budgets/strategy" },
+  { name: "Proto-DAOs / Gated Governance", ex: 2, vc: 0.72, mentions: 4, cat: "Structural", problems: ["Lack of clear purpose", "Token voting failure", "Governance theater"], actors: ["Eugene (concept)", "Various L2s"], examples: "Staked governance; progressive decentralization" },
+  { name: "Specialized Committees", ex: 3.5, vc: 0.65, mentions: 5, cat: "Structural", problems: ["Governance theater", "Lack of clear purpose", "Broken contributor economies"], actors: ["Scroll DAO", "Coffee-crusher"], examples: "Marketing, audits, treasury, proposal PM" },
+  { name: "Co-creation Cycles", ex: 3, vc: 0.62, mentions: 4, cat: "Sensemaking", problems: ["Governance theater", "Lack of clear purpose", "Token voting failure"], actors: ["Scroll DAO", "NEAR"], examples: "Collaborative design processes for proposals" },
+  { name: "Signals Protocol", ex: 2.5, vc: 0.60, mentions: 3, cat: "Sensemaking", problems: ["Token voting failure", "Voting fatigue", "Lack of clear purpose"], actors: ["Lighthouse"], examples: "Signal values instead of voting on outcomes" },
+  { name: "RPGF", ex: 3, vc: 0.58, mentions: 4, cat: "Financial", problems: ["Broken contributor economies", "Delegate sustainability"], actors: ["Optimism", "Various"], examples: "Retroactive public goods funding" },
+  { name: "AI Governance Agents", ex: 2, vc: 0.55, mentions: 4, cat: "AI-Augmented", problems: ["Voting fatigue", "Token voting failure", "Institutional amnesia"], actors: ["Clawdbot builders", "Martin"], examples: "Personal AI voting; NLP proposal summarization" },
+  { name: "Platform Cooperatives", ex: 2, vc: 0.52, mentions: 2, cat: "Alternative", problems: ["Governance theater", "Technical & legal gaps", "Lack of clear purpose"], actors: ["Joseph", "Public AI Network"], examples: "Platforms as public infrastructure" },
+  { name: "Soulbound / Reputation Tokens", ex: 3, vc: 0.48, mentions: 6, cat: "Reputation", problems: ["Token voting failure", "Broken contributor economies", "Informal power", "Delegate sustainability"], actors: ["Kokonut Network", "Wasabi", "Hats Protocol", "DAO Haus"], examples: "Burned to release voting power; merit-based roles" },
+  { name: "Delegate Verification", ex: 3, vc: 0.45, mentions: 4, cat: "Reputation", problems: ["Token voting failure", "Delegate sustainability", "Informal power"], actors: ["Scroll DAO", "Forward", "DeepDAO"], examples: "Verified delegate status for consistent compensation" },
+  { name: "VE / Buyback Models", ex: 4.5, vc: 0.38, mentions: 3, cat: "Financial", problems: ["Token voting failure", "Governance theater"], actors: ["Curve", "Aerodrome"], examples: "Vote-escrowed tokens; buyback-and-burn" },
+  { name: "AI Dispute Resolution", ex: 2, vc: 0.33, mentions: 2, cat: "AI-Augmented", problems: ["Technical & legal gaps", "Over-reliance on game theory"], actors: ["immediacy.ai"], examples: "Sim-juries interpreting programmatic ethics" },
+  { name: "Governance Memory System", ex: 2, vc: 0.28, mentions: 3, cat: "Knowledge", problems: ["Institutional amnesia", "Over-reliance on game theory", "Governance theater"], actors: ["Othman (GMS framework)"], examples: "5-layer framework: lifecycle, reviews, themes, power, diagnostics" },
+  { name: "Reference IDs (RIDs)", ex: 2.5, vc: 0.22, mentions: 2, cat: "Knowledge", problems: ["Institutional amnesia", "Informal power"], actors: ["Metagov KOI group"], examples: "Tagging knowledge objects across platforms" },
+  { name: "Telescope Bot", ex: 3, vc: 0.19, mentions: 1, cat: "Knowledge", problems: ["Institutional amnesia", "Informal power"], actors: ["Ellie Rennie"], examples: "Flags high-signal Discord comments" },
+  { name: "Tensegrity Governance", ex: 1.5, vc: 0.13, mentions: 3, cat: "Structural", problems: ["Over-reliance on game theory", "Governance theater", "Lack of clear purpose", "Informal power"], actors: ["Durgadas"], examples: "Hold paradoxes in dynamic tension; constitutional space for contradictions" },
+  { name: "VERP Protocol", ex: 1.5, vc: 0.08, mentions: 1, cat: "Verification", problems: ["Technical & legal gaps", "Token voting failure"], actors: ["Della Foresta"], examples: "Biometric identity + sensor networks" },
+];
+
+const catColors = {
+  "Voting Reform": "#f85149",
+  "Reputation": "#ffa657",
+  "AI-Augmented": "#d2a8ff",
+  "Sensemaking": "#79c0ff",
+  "Knowledge": "#56d364",
+  "Structural": "#ff7b72",
+  "Financial": "#ffd866",
+  "Verification": "#7ee787",
+  "Alternative": "#8b949e",
+};
+
+const deps = [
+  ["Conviction Voting", "VE / Buyback Models"],
+  ["Conviction Voting", "Soulbound / Reputation Tokens"],
+  ["Optimistic Governance", "Specialized Committees"],
+  ["Polis / Opinion Clustering", "Signals Protocol"],
+  ["Polis / Opinion Clustering", "Co-creation Cycles"],
+  ["Contributor Streams", "RPGF"],
+  ["Contributor Streams", "Delegate Verification"],
+  ["Centralized Ops + DAO Oversight", "Specialized Committees"],
+  ["Proto-DAOs / Gated Governance", "AI Governance Agents"],
+  ["Co-creation Cycles", "Governance Memory System"],
+  ["Signals Protocol", "Governance Memory System"],
+  ["Soulbound / Reputation Tokens", "Delegate Verification"],
+  ["Delegate Verification", "Reference IDs (RIDs)"],
+  ["AI Governance Agents", "AI Dispute Resolution"],
+  ["AI Governance Agents", "Governance Memory System"],
+  ["Governance Memory System", "Reference IDs (RIDs)"],
+  ["Governance Memory System", "Telescope Bot"],
+  ["Tensegrity Governance", "VERP Protocol"],
+  ["Platform Cooperatives", "Tensegrity Governance"],
+  ["RPGF", "Soulbound / Reputation Tokens"],
+];
+
+const svg = document.getElementById('map');
+const tip = document.getElementById('tip');
+
+const margin = { top: 100, right: 40, bottom: 60, left: 72 };
+
+function render() {
+  const W = window.innerWidth;
+  const H = window.innerHeight;
+  svg.setAttribute('viewBox', `0 0 ${W} ${H}`);
+
+  const pw = W - margin.left - margin.right;
+  const ph = H - margin.top - margin.bottom;
+
+  const sx = ex => margin.left + ((ex - 1) / 4) * pw;
+  const sy = vc => margin.top + (1 - vc) * ph;
+
+  let out = '';
+
+  // --- Defs ---
+  out += `<defs>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="6" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <linearGradient id="evo-grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f85149" stop-opacity="0.15"/>
+      <stop offset="33%" stop-color="#d2a8ff" stop-opacity="0.08"/>
+      <stop offset="66%" stop-color="#79c0ff" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#7ee787" stop-opacity="0.08"/>
+    </linearGradient>
+  </defs>`;
+
+  // --- Background terrain contour lines ---
+  // Subtle topographic-style concentric curves radiating from densest cluster area
+  const cx0 = sx(3), cy0 = sy(0.65);
+  for (let i = 1; i <= 8; i++) {
+    const rx = i * pw * 0.065;
+    const ry = i * ph * 0.055;
+    out += `<ellipse cx="${cx0}" cy="${cy0}" rx="${rx}" ry="${ry}" fill="none" stroke="#1a2029" stroke-width="0.5" stroke-opacity="${0.6 - i * 0.06}" />`;
+  }
+
+  // --- Evolution stage zones ---
+  const zones = [
+    { x0: 1, x1: 2, fill: 'var(--genesis)' },
+    { x0: 2, x1: 3, fill: 'var(--custom)' },
+    { x0: 3, x1: 4, fill: 'var(--product)' },
+    { x0: 4, x1: 5, fill: 'var(--commodity)' },
+  ];
+  zones.forEach(z => {
+    out += `<rect x="${sx(z.x0)}" y="${margin.top}" width="${sx(z.x1) - sx(z.x0)}" height="${ph}" fill="${z.fill}" />`;
+  });
+
+  // --- Grid ---
+  // Vertical stage dividers
+  for (let i = 2; i <= 4; i++) {
+    out += `<line x1="${sx(i)}" y1="${margin.top}" x2="${sx(i)}" y2="${margin.top + ph}" stroke="#1e2836" stroke-width="1" stroke-dasharray="2,6" />`;
+  }
+  // Horizontal dashed
+  for (let v = 0; v <= 1.01; v += 0.1) {
+    out += `<line x1="${margin.left}" y1="${sy(v)}" x2="${margin.left + pw}" y2="${sy(v)}" stroke="#151c24" stroke-width="0.5" stroke-dasharray="1,8" />`;
+  }
+  // Border
+  out += `<rect x="${margin.left}" y="${margin.top}" width="${pw}" height="${ph}" fill="none" stroke="#1e2836" stroke-width="1" />`;
+
+  // --- Axis labels ---
+  // Evolution stages bottom
+  const stageLabels = [
+    { x: 1.5, t: 'I · Genesis', sub: 'novel / rare' },
+    { x: 2.5, t: 'II · Custom', sub: 'emerging / chaotic' },
+    { x: 3.5, t: 'III · Product', sub: 'growing / stable' },
+    { x: 4.5, t: 'IV · Commodity', sub: 'industrialised' },
+  ];
+  stageLabels.forEach(s => {
+    out += `<text x="${sx(s.x)}" y="${margin.top + ph + 22}" text-anchor="middle" fill="#5a6a7a" font-size="10" font-family="IBM Plex Mono" font-weight="400" letter-spacing="0.04em">${s.t}</text>`;
+    out += `<text x="${sx(s.x)}" y="${margin.top + ph + 36}" text-anchor="middle" fill="#3d4a58" font-size="8.5" font-family="IBM Plex Mono" font-weight="300">${s.sub}</text>`;
+  });
+
+  // Evolution arrow
+  out += `<text x="${margin.left + pw / 2}" y="${H - 8}" text-anchor="middle" fill="#3d4a58" font-size="8.5" font-family="IBM Plex Mono" font-weight="300" letter-spacing="0.12em">EVOLUTION ───────→</text>`;
+
+  // Y-axis: value chain
+  const vcLabels = [
+    { v: 0.92, t: 'VISIBLE' },
+    { v: 0.78, t: 'participant-facing' },
+    { v: 0.55, t: 'enabling' },
+    { v: 0.30, t: 'infrastructure' },
+    { v: 0.06, t: 'INVISIBLE' },
+  ];
+  vcLabels.forEach(l => {
+    const isEdge = l.t === 'VISIBLE' || l.t === 'INVISIBLE';
+    out += `<text x="${margin.left - 10}" y="${sy(l.v) + 3}" text-anchor="end" fill="${isEdge ? '#3d4a58' : '#4a5568'}" font-size="${isEdge ? '7.5' : '8.5'}" font-family="IBM Plex Mono" font-weight="${isEdge ? '300' : '400'}" letter-spacing="${isEdge ? '0.15em' : '0.04em'}">${l.t}</text>`;
+  });
+  // Y-axis arrow (rotated)
+  out += `<text x="16" y="${margin.top + ph / 2}" text-anchor="middle" fill="#3d4a58" font-size="8.5" font-family="IBM Plex Mono" font-weight="300" letter-spacing="0.12em" transform="rotate(-90 16 ${margin.top + ph / 2})">VALUE CHAIN ───────→</text>`;
+
+  // --- Dependency lines ---
+  const nameMap = {};
+  solutions.forEach(s => { nameMap[s.name] = s; });
+
+  deps.forEach(([from, to]) => {
+    const a = nameMap[from], b = nameMap[to];
+    if (!a || !b) return;
+    out += `<line class="dep" data-from="${from}" data-to="${to}" x1="${sx(a.ex)}" y1="${sy(a.vc)}" x2="${sx(b.ex)}" y2="${sy(b.vc)}" stroke="#2a3544" stroke-width="1" stroke-opacity="0.35" />`;
+  });
+
+  // --- Nodes ---
+  solutions.forEach((s, i) => {
+    const cx = sx(s.ex);
+    const cy = sy(s.vc);
+    const r = s.mentions * 3 + 5;
+    const color = catColors[s.cat];
+    const delay = (i * 0.04).toFixed(2);
+
+    out += `<g class="node-g" data-idx="${i}" style="animation-delay:${delay}s;transform-origin:${cx}px ${cy}px">`;
+
+    // Outer glow ring
+    out += `<circle cx="${cx}" cy="${cy}" r="${r + 4}" fill="none" stroke="${color}" stroke-width="0.5" stroke-opacity="0.15" />`;
+
+    // Main circle
+    out += `<circle class="node-circle" cx="${cx}" cy="${cy}" r="${r}" fill="${color}" fill-opacity="0.75" stroke="${color}" stroke-width="1.5" stroke-opacity="0.25" style="cursor:pointer;transition:fill-opacity 0.15s,r 0.2s" />`;
+
+    // Inner highlight dot
+    out += `<circle cx="${cx - r * 0.25}" cy="${cy - r * 0.25}" r="${r * 0.2}" fill="white" fill-opacity="0.12" />`;
+
+    // Label positioning — smart placement
+    const labelText = s.name;
+    let lx, la;
+    // Right side by default, left if too far right
+    if (cx > margin.left + pw * 0.82) {
+      lx = cx - r - 8; la = 'end';
+    } else {
+      lx = cx + r + 8; la = 'start';
+    }
+
+    // Multi-line support
+    const lines = labelText.split(' / ');
+    let singleLine = lines.length === 1;
+    if (singleLine && labelText.length > 22) {
+      // Split long names at natural break
+      const mid = Math.floor(labelText.length / 2);
+      const spaceAfter = labelText.indexOf(' ', mid);
+      const spaceBefore = labelText.lastIndexOf(' ', mid);
+      const splitAt = (mid - spaceBefore < spaceAfter - mid) ? spaceBefore : spaceAfter;
+      if (splitAt > 0) {
+        const parts = [labelText.substring(0, splitAt), labelText.substring(splitAt + 1)];
+        parts.forEach((p, pi) => {
+          out += `<text class="node-label" data-idx="${i}" x="${lx}" y="${cy + 4 + pi * 13 - 6}" text-anchor="${la}" fill="#b8c4d0" fill-opacity="0.9" font-size="10" font-family="IBM Plex Mono" font-weight="400" style="pointer-events:none;transition:fill-opacity 0.15s">${p}</text>`;
+        });
+      } else {
+        out += `<text class="node-label" data-idx="${i}" x="${lx}" y="${cy + 4}" text-anchor="${la}" fill="#b8c4d0" fill-opacity="0.9" font-size="10" font-family="IBM Plex Mono" font-weight="400" style="pointer-events:none;transition:fill-opacity 0.15s">${labelText}</text>`;
+      }
+    } else if (!singleLine) {
+      lines.forEach((line, li) => {
+        out += `<text class="node-label" data-idx="${i}" x="${lx}" y="${cy + 4 + li * 13 - (lines.length - 1) * 6}" text-anchor="${la}" fill="#b8c4d0" fill-opacity="0.9" font-size="10" font-family="IBM Plex Mono" font-weight="400" style="pointer-events:none;transition:fill-opacity 0.15s">${line.trim()}</text>`;
+      });
+    } else {
+      out += `<text class="node-label" data-idx="${i}" x="${lx}" y="${cy + 4}" text-anchor="${la}" fill="#b8c4d0" fill-opacity="0.9" font-size="10" font-family="IBM Plex Mono" font-weight="400" style="pointer-events:none;transition:fill-opacity 0.15s">${labelText}</text>`;
+    }
+
+    out += `</g>`;
+  });
+
+  // --- Coordinate crosshairs in corners ---
+  const ch = [
+    { x: margin.left + 8, y: margin.top + 14, t: '0,1' },
+    { x: margin.left + pw - 8, y: margin.top + 14, t: '1,1' },
+    { x: margin.left + 8, y: margin.top + ph - 6, t: '0,0' },
+    { x: margin.left + pw - 8, y: margin.top + ph - 6, t: '1,0' },
+  ];
+  ch.forEach(c => {
+    out += `<text x="${c.x}" y="${c.y}" text-anchor="${c.x < W / 2 ? 'start' : 'end'}" fill="#1e2836" font-size="8" font-family="IBM Plex Mono" font-weight="300">${c.t}</text>`;
+  });
+
+  svg.innerHTML = out;
+
+  // --- Interactions ---
+  const nodeGroups = svg.querySelectorAll('.node-g');
+  const allCircles = svg.querySelectorAll('.node-circle');
+  const allLabels = svg.querySelectorAll('.node-label');
+  const allDeps = svg.querySelectorAll('.dep');
+
+  nodeGroups.forEach(g => {
+    const circle = g.querySelector('.node-circle');
+    if (!circle) return;
+    const idx = parseInt(g.dataset.idx);
+    const s = solutions[idx];
+    const color = catColors[s.cat];
+
+    const onEnter = (e) => {
+      // Find connected
+      const connected = new Set();
+      deps.forEach(([from, to]) => {
+        if (from === s.name) connected.add(to);
+        if (to === s.name) connected.add(from);
+      });
+      const connectedIdx = new Set();
+      solutions.forEach((o, oi) => { if (connected.has(o.name)) connectedIdx.add(oi); });
+
+      // Dim everything
+      allCircles.forEach(c => { c.setAttribute('fill-opacity', '0.08'); c.setAttribute('stroke-opacity', '0.03'); });
+      allLabels.forEach(l => { l.setAttribute('fill-opacity', '0.08'); });
+      allDeps.forEach(d => { d.setAttribute('stroke-opacity', '0.04'); });
+      // Glow rings
+      nodeGroups.forEach(ng => {
+        const ring = ng.querySelectorAll('circle')[0];
+        if (ring) ring.setAttribute('stroke-opacity', '0.02');
+      });
+
+      // Highlight this
+      circle.setAttribute('fill-opacity', '1');
+      circle.setAttribute('stroke-opacity', '0.6');
+      const baseR = s.mentions * 3 + 5;
+      circle.setAttribute('r', baseR * 1.25);
+      circle.setAttribute('filter', 'url(#glow)');
+      g.querySelectorAll('circle')[0].setAttribute('stroke-opacity', '0.4');
+      svg.querySelectorAll(`.node-label[data-idx="${idx}"]`).forEach(l => {
+        l.setAttribute('fill-opacity', '1');
+        l.setAttribute('fill', '#e2e8f0');
+      });
+
+      // Highlight connected
+      connectedIdx.forEach(ci => {
+        const cg = svg.querySelector(`.node-g[data-idx="${ci}"]`);
+        if (cg) {
+          const cc = cg.querySelector('.node-circle');
+          if (cc) { cc.setAttribute('fill-opacity', '0.55'); cc.setAttribute('stroke-opacity', '0.2'); cc.setAttribute('filter', 'url(#softglow)'); }
+          cg.querySelectorAll('circle')[0].setAttribute('stroke-opacity', '0.1');
+        }
+        svg.querySelectorAll(`.node-label[data-idx="${ci}"]`).forEach(l => l.setAttribute('fill-opacity', '0.65'));
+      });
+
+      // Highlight dep lines
+      allDeps.forEach(d => {
+        if (d.dataset.from === s.name || d.dataset.to === s.name) {
+          d.setAttribute('stroke', color);
+          d.setAttribute('stroke-opacity', '0.7');
+          d.setAttribute('stroke-width', '1.5');
+        }
+      });
+
+      // Tooltip
+      tip.innerHTML = `
+        <div class="tt-name">${s.name}</div>
+        <div class="tt-cat" style="color:${color}">${s.cat}</div>
+        <div class="tt-tags">${s.problems.map(p => `<span class="tt-tag">${p}</span>`).join('')}</div>
+        <div class="tt-section"><b>Actors:</b> ${s.actors.join(', ')}</div>
+        <div class="tt-section" style="font-style:italic">${s.examples}</div>
+        <div class="tt-mentions">${s.mentions} participant mention${s.mentions > 1 ? 's' : ''}</div>
+      `;
+      tip.style.opacity = '1';
+    };
+
+    const onMove = (e) => {
+      let left = e.clientX + 18;
+      let top = e.clientY - 12;
+      if (left + 300 > W) left = e.clientX - 310;
+      if (top + 200 > H) top = e.clientY - 200;
+      tip.style.left = left + 'px';
+      tip.style.top = top + 'px';
+    };
+
+    const onLeave = () => {
+      allCircles.forEach((c, ci) => {
+        c.setAttribute('fill-opacity', '0.75');
+        c.setAttribute('stroke-opacity', '0.25');
+        c.setAttribute('r', solutions[ci].mentions * 3 + 5);
+        c.removeAttribute('filter');
+      });
+      allLabels.forEach(l => { l.setAttribute('fill-opacity', '0.9'); l.setAttribute('fill', '#b8c4d0'); });
+      allDeps.forEach(d => { d.setAttribute('stroke', '#2a3544'); d.setAttribute('stroke-opacity', '0.35'); d.setAttribute('stroke-width', '1'); });
+      nodeGroups.forEach(ng => {
+        const ring = ng.querySelectorAll('circle')[0];
+        if (ring) ring.setAttribute('stroke-opacity', '0.15');
+      });
+      tip.style.opacity = '0';
+    };
+
+    circle.addEventListener('mouseenter', onEnter);
+    circle.addEventListener('mousemove', onMove);
+    circle.addEventListener('mouseleave', onLeave);
+    // Also trigger on label hover
+    g.querySelectorAll('.node-label').forEach(l => {
+      l.style.pointerEvents = 'auto';
+      l.style.cursor = 'pointer';
+      l.addEventListener('mouseenter', onEnter);
+      l.addEventListener('mousemove', onMove);
+      l.addEventListener('mouseleave', onLeave);
+    });
+  });
+}
+
+render();
+let resizeTimer;
+window.addEventListener('resize', () => {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(render, 100);
+});
+
+// Legend
+const legendEl = document.getElementById('legend');
+const categories = [...new Set(solutions.map(s => s.cat))];
+let activeFilter = null;
+
+categories.forEach(cat => {
+  const item = document.createElement('div');
+  item.className = 'lg';
+  item.innerHTML = `<div class="sw" style="background:${catColors[cat]}"></div>${cat}`;
+  item.addEventListener('click', () => {
+    if (activeFilter === cat) {
+      activeFilter = null;
+      document.querySelectorAll('.lg').forEach(l => l.classList.remove('dimmed'));
+      document.querySelectorAll('.node-circle').forEach((c, ci) => {
+        c.setAttribute('fill-opacity', '0.75');
+        c.setAttribute('stroke-opacity', '0.25');
+      });
+      document.querySelectorAll('.node-label').forEach(l => l.setAttribute('fill-opacity', '0.9'));
+      document.querySelectorAll('.dep').forEach(d => d.setAttribute('stroke-opacity', '0.35'));
+      document.querySelectorAll('.node-g').forEach(ng => {
+        ng.querySelectorAll('circle')[0].setAttribute('stroke-opacity', '0.15');
+      });
+    } else {
+      activeFilter = cat;
+      document.querySelectorAll('.lg').forEach(l => {
+        l.classList.toggle('dimmed', !l.textContent.includes(cat));
+      });
+      solutions.forEach((s, i) => {
+        const match = s.cat === cat;
+        const circle = document.querySelectorAll('.node-circle')[i];
+        if (circle) {
+          circle.setAttribute('fill-opacity', match ? '0.9' : '0.06');
+          circle.setAttribute('stroke-opacity', match ? '0.4' : '0.02');
+        }
+        document.querySelectorAll(`.node-label[data-idx="${i}"]`).forEach(l => {
+          l.setAttribute('fill-opacity', match ? '1' : '0.06');
+        });
+        const ng = document.querySelector(`.node-g[data-idx="${i}"]`);
+        if (ng) ng.querySelectorAll('circle')[0].setAttribute('stroke-opacity', match ? '0.2' : '0.02');
+      });
+      // Show deps only between matching nodes
+      document.querySelectorAll('.dep').forEach(d => {
+        const fromCat = nameMap[d.dataset.from]?.cat;
+        const toCat = nameMap[d.dataset.to]?.cat;
+        const relevant = fromCat === cat || toCat === cat;
+        d.setAttribute('stroke-opacity', relevant ? '0.4' : '0.03');
+      });
+    }
+  });
+  legendEl.appendChild(item);
+});
+
+const nameMap = {};
+solutions.forEach(s => { nameMap[s.name] = s; });
+</script>
+</body>
+</html>

--- a/phase1/solutions.html
+++ b/phase1/solutions.html
@@ -1,0 +1,479 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>gov/acc — Solutions Landscape</title>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300&display=swap" rel="stylesheet">
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    background: #0d1117;
+    color: #c9d1d9;
+    font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    min-height: 100vh;
+    overflow-x: hidden;
+  }
+
+  header {
+    text-align: center;
+    padding: 28px 20px 6px;
+  }
+  header h1 {
+    font-size: 1.35em;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+  }
+  header h1 span { color: #7ee787; }
+  header .sub {
+    color: #8b949e;
+    font-size: 0.82em;
+    margin-top: 4px;
+  }
+
+  /* Axes labels */
+  .x-axis {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 14px 20px 2px;
+    color: #8b949e;
+    font-size: 0.75em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .x-axis .arrow {
+    flex: 0 0 auto;
+    width: 40px;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, #484f58);
+    position: relative;
+  }
+  .x-axis .arrow::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: -3px;
+    border: 3px solid transparent;
+    border-left: 5px solid #484f58;
+  }
+  .x-axis .arrow.left {
+    background: linear-gradient(90deg, #484f58, transparent);
+  }
+  .x-axis .arrow.left::after {
+    right: auto;
+    left: 0;
+    border-left: none;
+    border-right: 5px solid #484f58;
+  }
+
+  /* Y-axis indicator */
+  .y-indicator {
+    position: fixed;
+    left: 8px;
+    top: 50%;
+    transform: translateY(-50%) rotate(-90deg);
+    color: #484f58;
+    font-size: 0.7em;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 10;
+  }
+
+  /* Main grid */
+  .landscape {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 2px;
+    padding: 8px 36px 24px;
+    min-height: calc(100vh - 140px);
+  }
+
+  .maturity-col {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .col-header {
+    text-align: center;
+    padding: 10px 4px;
+    font-size: 0.78em;
+    font-weight: 500;
+    color: #e6edf3;
+    letter-spacing: 0.02em;
+    border-bottom: 1px solid #21262d;
+    position: relative;
+  }
+  .col-header .stage-num {
+    display: block;
+    font-size: 2em;
+    font-weight: 300;
+    color: #21262d;
+    line-height: 1;
+    margin-bottom: 2px;
+  }
+
+  .col-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 4px;
+  }
+
+  /* Solution cards */
+  .card {
+    position: relative;
+    border-radius: 8px;
+    padding: 10px 11px;
+    cursor: default;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.15s ease;
+    border: 1px solid transparent;
+    background: #161b22;
+  }
+  .card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+    z-index: 20;
+    border-color: var(--cat-color);
+  }
+
+  .card-top {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin-bottom: 6px;
+  }
+
+  .card .dot {
+    flex-shrink: 0;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-top: 4px;
+    background: var(--cat-color);
+  }
+
+  .card .name {
+    font-size: 0.82em;
+    font-weight: 500;
+    color: #e6edf3;
+    line-height: 1.25;
+  }
+
+  .card .mentions-badge {
+    margin-left: auto;
+    flex-shrink: 0;
+    background: rgba(255,255,255,0.06);
+    color: #8b949e;
+    font-size: 0.7em;
+    padding: 2px 6px;
+    border-radius: 10px;
+    white-space: nowrap;
+  }
+
+  .card .meta {
+    font-size: 0.72em;
+    color: #8b949e;
+    line-height: 1.35;
+  }
+  .card .meta .cat-label {
+    color: var(--cat-color);
+    font-weight: 500;
+  }
+
+  /* Problems bar */
+  .problems-bar {
+    display: flex;
+    gap: 2px;
+    margin-top: 6px;
+  }
+  .problems-bar .pip {
+    height: 3px;
+    flex: 1;
+    border-radius: 1.5px;
+    background: var(--cat-color);
+    opacity: 0.5;
+  }
+
+  /* Expanded detail on hover */
+  .card .detail {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease, opacity 0.2s ease;
+    opacity: 0;
+  }
+  .card:hover .detail {
+    max-height: 200px;
+    opacity: 1;
+    margin-top: 8px;
+  }
+
+  .detail .section {
+    font-size: 0.72em;
+    color: #8b949e;
+    margin-bottom: 4px;
+    line-height: 1.4;
+  }
+  .detail .section b {
+    color: #c9d1d9;
+    font-weight: 500;
+  }
+
+  .detail .problem-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px;
+    margin-top: 4px;
+  }
+  .detail .problem-tag {
+    font-size: 0.65em;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: rgba(255,255,255,0.05);
+    color: #c9d1d9;
+    border: 1px solid #21262d;
+  }
+
+  /* Legend */
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px 20px;
+    padding: 8px 20px 20px;
+  }
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.72em;
+    color: #8b949e;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+  .legend-item:hover { opacity: 0.7; }
+  .legend-item.dimmed { opacity: 0.25; }
+  .legend-item .swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 3px;
+  }
+
+  /* Quadrant hint watermarks */
+  .col-body .zone-hint {
+    font-size: 0.65em;
+    color: rgba(139,148,158,0.2);
+    text-align: center;
+    padding: 4px 0;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    pointer-events: none;
+  }
+
+  /* Filter dimming */
+  .card.dimmed {
+    opacity: 0.12;
+    transform: scale(0.97);
+  }
+
+  /* Responsive */
+  @media (max-width: 900px) {
+    .landscape {
+      grid-template-columns: repeat(3, 1fr);
+      padding: 8px 12px 24px;
+    }
+    .y-indicator { display: none; }
+  }
+  @media (max-width: 600px) {
+    .landscape {
+      grid-template-columns: 1fr 1fr;
+      padding: 8px 8px 24px;
+    }
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>gov/acc Phase 1 — <span>Solutions Landscape</span></h1>
+  <div class="sub">21 proposed solutions organized by maturity stage · card height ~ problems addressed · hover for details</div>
+</header>
+
+<div class="x-axis">
+  <span class="arrow left"></span>
+  <span>Early</span>
+  <span style="color:#484f58;margin:0 4px">·</span>
+  <span>Maturity</span>
+  <span style="color:#484f58;margin:0 4px">·</span>
+  <span>Established</span>
+  <span class="arrow"></span>
+</div>
+
+<div class="y-indicator">problems addressed &uarr;</div>
+
+<div class="landscape" id="landscape"></div>
+
+<div class="legend" id="legend"></div>
+
+<script>
+const solutions = [
+  { name: "Conviction Voting", x: 3.5, y: 3, mentions: 5, cat: "Voting Reform", problems: ["Token voting failure", "Voting fatigue", "Informal power"], actors: ["Various DAOs experimenting"], examples: "Weight votes by time held + participation history" },
+  { name: "Soulbound / Reputation Tokens", x: 3, y: 4, mentions: 6, cat: "Reputation", problems: ["Token voting failure", "Broken contributor economies", "Informal power", "Delegate sustainability"], actors: ["Kokonut Network", "Wasabi", "Hats Protocol", "DAO Haus"], examples: "Burned to release voting power; rage quit mechanics; merit-based roles" },
+  { name: "Delegate Verification", x: 3, y: 3, mentions: 4, cat: "Reputation", problems: ["Token voting failure", "Delegate sustainability", "Informal power"], actors: ["Scroll DAO", "Forward", "DeepDAO"], examples: "Verified delegate status for consistent compensation" },
+  { name: "AI Governance Agents", x: 2, y: 3, mentions: 4, cat: "AI-Augmented", problems: ["Voting fatigue", "Token voting failure", "Institutional amnesia"], actors: ["Clawdbot builders", "Martin (locally running agents)"], examples: "Personal AI voting according to user preferences; NLP proposal summarization" },
+  { name: "AI Dispute Resolution", x: 2, y: 2, mentions: 2, cat: "AI-Augmented", problems: ["Technical & legal gaps", "Over-reliance on game theory"], actors: ["immediacy.ai"], examples: "Sim-juries interpreting programmatic ethics" },
+  { name: "Polis / Opinion Clustering", x: 4, y: 3, mentions: 5, cat: "Sensemaking", problems: ["Token voting failure", "Informal power", "Voting fatigue"], actors: ["Polis", "Metagov"], examples: "Collective sensemaking through opinion mapping" },
+  { name: "Signals Protocol", x: 2.5, y: 3, mentions: 3, cat: "Sensemaking", problems: ["Token voting failure", "Voting fatigue", "Lack of clear purpose"], actors: ["Lighthouse"], examples: "Signal values instead of voting on outcomes" },
+  { name: "Co-creation Cycles", x: 3, y: 3, mentions: 4, cat: "Sensemaking", problems: ["Governance theater", "Lack of clear purpose", "Token voting failure"], actors: ["Scroll DAO", "NEAR"], examples: "Collaborative design processes for proposals" },
+  { name: "Governance Memory System", x: 2, y: 3, mentions: 3, cat: "Knowledge", problems: ["Institutional amnesia", "Over-reliance on game theory", "Governance theater"], actors: ["Othman (GMS framework)"], examples: "5-layer framework: proposal lifecycle, outcome reviews, themes, power mapping, diagnostics" },
+  { name: "Reference Identifiers (RIDs)", x: 2.5, y: 2, mentions: 2, cat: "Knowledge", problems: ["Institutional amnesia", "Informal power"], actors: ["Metagov KOI group"], examples: "Tagging knowledge objects across Discord, forums, GitHub" },
+  { name: "Telescope Bot", x: 3, y: 2, mentions: 1, cat: "Knowledge", problems: ["Institutional amnesia", "Informal power"], actors: ["Ellie Rennie"], examples: "Flags high-signal Discord comments for ethnographic review" },
+  { name: "Tensegrity Governance", x: 1.5, y: 4, mentions: 3, cat: "Structural", problems: ["Over-reliance on game theory", "Governance theater", "Lack of clear purpose", "Informal power"], actors: ["Durgadas"], examples: "Hold paradoxes in dynamic tension; multiple decision venues; constitutional space for contradictions" },
+  { name: "Optimistic Governance", x: 3.5, y: 2, mentions: 4, cat: "Structural", problems: ["Voting fatigue", "Governance theater"], actors: ["Various L2s"], examples: "Proposals pass unless challenged" },
+  { name: "Specialized Committees", x: 3.5, y: 3, mentions: 5, cat: "Structural", problems: ["Governance theater", "Lack of clear purpose", "Broken contributor economies"], actors: ["Scroll DAO", "Coffee-crusher proposal"], examples: "Marketing, audits, treasury, proposal PM — not just grants" },
+  { name: "Proto-DAOs / Gated Governance", x: 2, y: 3, mentions: 4, cat: "Structural", problems: ["Lack of clear purpose", "Token voting failure", "Governance theater"], actors: ["Eugene (concept)", "Various L2s"], examples: "Staked governance; progressive decentralization; prove PMF before decentralizing" },
+  { name: "Contributor Streams", x: 3.5, y: 2, mentions: 5, cat: "Financial", problems: ["Broken contributor economies", "Delegate sustainability"], actors: ["Scroll DAO", "Various DAOs"], examples: "Tiered: Bounties → Project Grants → Core Contributor Streams with vested tokens" },
+  { name: "RPGF", x: 3, y: 2, mentions: 4, cat: "Financial", problems: ["Broken contributor economies", "Delegate sustainability"], actors: ["Optimism", "Various"], examples: "Retroactive public goods funding with hybrid input-output valuation" },
+  { name: "VE / Buyback Models", x: 4.5, y: 2, mentions: 3, cat: "Financial", problems: ["Token voting failure", "Governance theater"], actors: ["Curve", "Aerodrome"], examples: "Vote-escrowed tokens; buyback-and-burn; revenue distribution" },
+  { name: "VERP Protocol", x: 1.5, y: 2, mentions: 1, cat: "Verification", problems: ["Technical & legal gaps", "Token voting failure"], actors: ["Della Foresta"], examples: "Biometric identity + sensor networks; 'executable cryptobiology'" },
+  { name: "Platform Cooperatives", x: 2, y: 3, mentions: 2, cat: "Alternative", problems: ["Governance theater", "Technical & legal gaps", "Lack of clear purpose"], actors: ["Joseph", "Public AI Network"], examples: "Platforms as public infrastructure; algorithmic transparency mandates" },
+  { name: "Centralized Ops + DAO Oversight", x: 3.5, y: 3, mentions: 5, cat: "Alternative", problems: ["Governance theater", "Lack of clear purpose", "Voting fatigue"], actors: ["a16z (concept)", "Various L2s"], examples: "Foundations run day-to-day; DAO approves budgets/strategy" },
+];
+
+const catColors = {
+  "Voting Reform": "#f85149",
+  "Reputation": "#ffa657",
+  "AI-Augmented": "#d2a8ff",
+  "Sensemaking": "#79c0ff",
+  "Knowledge": "#56d364",
+  "Structural": "#ff7b72",
+  "Financial": "#ffd866",
+  "Verification": "#7ee787",
+  "Alternative": "#8b949e",
+};
+
+// Assign solutions to maturity columns
+// 1-1.75 → Idea, 1.75-2.25 → Research, 2.25-3.25 → Pilot, 3.25-4.25 → Production, 4.25-5 → Established
+function getColumn(x) {
+  if (x < 1.75) return 0;
+  if (x < 2.75) return 1;
+  if (x < 3.25) return 2;
+  if (x < 4.25) return 3;
+  return 4;
+}
+
+const colLabels = ['Idea', 'Research', 'Pilot', 'Production', 'Established'];
+const colNums = ['01', '02', '03', '04', '05'];
+
+// Bucket solutions into columns, sorted by y (problems addressed) descending
+const buckets = [[], [], [], [], []];
+solutions.forEach(s => {
+  buckets[getColumn(s.x)].push(s);
+});
+buckets.forEach(b => b.sort((a, bb) => bb.y - a.y));
+
+const landscape = document.getElementById('landscape');
+
+buckets.forEach((items, colIdx) => {
+  const col = document.createElement('div');
+  col.className = 'maturity-col';
+
+  const header = document.createElement('div');
+  header.className = 'col-header';
+  header.innerHTML = '<span class="stage-num">' + colNums[colIdx] + '</span>' + colLabels[colIdx];
+  col.appendChild(header);
+
+  const body = document.createElement('div');
+  body.className = 'col-body';
+
+  items.forEach(s => {
+    const card = document.createElement('div');
+    card.className = 'card';
+    card.dataset.cat = s.cat;
+    card.style.setProperty('--cat-color', catColors[s.cat]);
+
+    // Top row: dot + name + mentions badge
+    const top = document.createElement('div');
+    top.className = 'card-top';
+    top.innerHTML =
+      '<div class="dot"></div>' +
+      '<div class="name">' + s.name + '</div>' +
+      '<div class="mentions-badge">' + s.mentions + (s.mentions === 1 ? ' mention' : ' mentions') + '</div>';
+    card.appendChild(top);
+
+    // Meta line
+    const meta = document.createElement('div');
+    meta.className = 'meta';
+    meta.innerHTML = '<span class="cat-label">' + s.cat + '</span> · ' + s.y + ' problem' + (s.y !== 1 ? 's' : '') + ' addressed';
+    card.appendChild(meta);
+
+    // Problems bar (visual pip per problem)
+    const bar = document.createElement('div');
+    bar.className = 'problems-bar';
+    for (let i = 0; i < s.y; i++) {
+      const pip = document.createElement('div');
+      pip.className = 'pip';
+      bar.appendChild(pip);
+    }
+    card.appendChild(bar);
+
+    // Expandable detail
+    const detail = document.createElement('div');
+    detail.className = 'detail';
+    detail.innerHTML =
+      '<div class="section"><b>Addresses:</b></div>' +
+      '<div class="problem-tags">' + s.problems.map(p => '<span class="problem-tag">' + p + '</span>').join('') + '</div>' +
+      '<div class="section" style="margin-top:6px"><b>Actors:</b> ' + s.actors.join(', ') + '</div>' +
+      '<div class="section"><b>How:</b> ' + s.examples + '</div>';
+    card.appendChild(detail);
+
+    body.appendChild(card);
+  });
+
+  if (items.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'zone-hint';
+    empty.textContent = 'no solutions mapped here';
+    body.appendChild(empty);
+  }
+
+  col.appendChild(body);
+  landscape.appendChild(col);
+});
+
+// Legend with filtering
+const legendEl = document.getElementById('legend');
+const categories = [...new Set(solutions.map(s => s.cat))];
+let activeFilter = null;
+
+categories.forEach(cat => {
+  const item = document.createElement('div');
+  item.className = 'legend-item';
+  item.innerHTML = '<div class="swatch" style="background:' + catColors[cat] + '"></div>' + cat;
+  item.addEventListener('click', () => {
+    if (activeFilter === cat) {
+      // Deselect
+      activeFilter = null;
+      document.querySelectorAll('.card').forEach(c => c.classList.remove('dimmed'));
+      document.querySelectorAll('.legend-item').forEach(l => l.classList.remove('dimmed'));
+    } else {
+      activeFilter = cat;
+      document.querySelectorAll('.card').forEach(c => {
+        c.classList.toggle('dimmed', c.dataset.cat !== cat);
+      });
+      document.querySelectorAll('.legend-item').forEach(l => {
+        l.classList.toggle('dimmed', !l.textContent.includes(cat));
+      });
+    }
+  });
+  legendEl.appendChild(item);
+});
+</script>
+</body>
+</html>

--- a/phase1/urgency.html
+++ b/phase1/urgency.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>gov/acc — Urgency Matrix</title>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+<style>
+  body { margin: 0; background: #0d1117; color: #c9d1d9; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  h1 { text-align: center; padding: 24px 0 0; font-size: 1.4em; font-weight: 500; }
+  h1 span { color: #7ee787; }
+  p.sub { text-align: center; color: #8b949e; font-size: 0.85em; margin: 4px 0 0; }
+  p.legend { text-align: center; color: #8b949e; font-size: 0.8em; margin: 8px 0 4px; }
+  #chart { width: 100%; height: calc(100vh - 100px); }
+</style>
+</head>
+<body>
+<h1>gov/acc Phase 1 — <span>Urgency Matrix</span></h1>
+<p class="sub">Bubble size = number of participants who raised each problem · Position = breadth vs depth of discussion</p>
+<p class="legend">X: how many people mentioned it · Y: average depth of engagement (messages spent discussing)</p>
+<div id="chart"></div>
+<script>
+// Data derived from 19 completed conversations
+// x = number of distinct participants who raised this problem
+// y = average messages spent on this problem per participant who raised it (depth proxy)
+// size = x (scaled)
+const problems = [
+  {
+    label: "Token Voting Failure\n& Plutocracy",
+    x: 12,
+    y: 4.2,
+    who: "Eugene, Zeugh, Malachite, Hima,\nMarlene, Alex Soto, Trigs, Raphael,\nArtem, Chris, Regis, Ivey"
+  },
+  {
+    label: "Governance Theater\n& Recentralization",
+    x: 9,
+    y: 3.8,
+    who: "Coffee-crusher, Ivey, Carl, Alex Soto,\nMarlene, Chris, Zeugh, Hima, Trigs"
+  },
+  {
+    label: "Broken Contributor\nEconomies",
+    x: 7,
+    y: 5.1,
+    who: "Marlene, Alex Soto, Coffee-crusher,\nZeugh, Raphael, Malachite, Chris"
+  },
+  {
+    label: "Informal Power\n& Narrative Capture",
+    x: 6,
+    y: 3.5,
+    who: "Othman, Zeugh, Marlene,\nAlex Soto, Trigs, Hima"
+  },
+  {
+    label: "Institutional\nAmnesia",
+    x: 5,
+    y: 5.8,
+    who: "Othman, Artem, Eugene,\nRegis, Martin"
+  },
+  {
+    label: "Lack of Clear\nPurpose",
+    x: 5,
+    y: 3.2,
+    who: "Eugene, Raphael, Carl,\nCoffee-crusher, Ivey"
+  },
+  {
+    label: "Over-Reliance on\nGame Theory",
+    x: 4,
+    y: 6.5,
+    who: "Regis, Martin, Durgadas\n(via Regis), Artem"
+  },
+  {
+    label: "Technical &\nLegal Gaps",
+    x: 4,
+    y: 4.8,
+    who: "Della Foresta, Jason C,\nJoseph, Hima"
+  },
+  {
+    label: "Voting Fatigue\n& Apathy",
+    x: 8,
+    y: 2.8,
+    who: "Eugene, Martin, Trigs, Hima,\nRaphael, Zeugh, Marlene, Ivey"
+  },
+  {
+    label: "Delegate\nSustainability",
+    x: 5,
+    y: 4.0,
+    who: "Marlene, Alex Soto, Zeugh,\nMalachite, Coffee-crusher"
+  },
+];
+
+const x = problems.map(p => p.x);
+const y = problems.map(p => p.y);
+const text = problems.map(p => p.label);
+const hover = problems.map(p =>
+  '<b>' + p.label.replace('\n', ' ') + '</b><br>' +
+  'Mentioned by: ' + p.x + ' participants<br>' +
+  'Avg depth: ' + p.y.toFixed(1) + ' messages<br><br>' +
+  p.who
+);
+const sizes = x.map(v => v * 6 + 10);
+
+// Color by quadrant logic: high breadth + high depth = most urgent
+const colors = problems.map(p => {
+  const score = (p.x / 12) * 0.6 + (p.y / 6.5) * 0.4;
+  if (score > 0.7) return 'rgba(248,81,73,0.9)';      // critical
+  if (score > 0.5) return 'rgba(255,166,87,0.9)';      // high
+  if (score > 0.35) return 'rgba(255,214,102,0.9)';    // medium
+  return 'rgba(126,231,135,0.7)';                       // lower
+});
+
+Plotly.newPlot('chart', [{
+  type: 'scatter',
+  mode: 'markers+text',
+  x: x,
+  y: y,
+  text: text,
+  textposition: problems.map((p, i) => {
+    // Avoid label collisions
+    if (p.label.includes('Voting Fatigue')) return 'bottom center';
+    if (p.label.includes('Delegate')) return 'top left';
+    if (p.label.includes('Lack of')) return 'bottom right';
+    if (p.label.includes('Informal')) return 'top right';
+    if (p.label.includes('Institutional')) return 'top center';
+    if (p.label.includes('Technical')) return 'top right';
+    if (p.label.includes('Game Theory')) return 'top left';
+    if (p.label.includes('Contributor')) return 'top center';
+    return 'top center';
+  }),
+  textfont: { size: 11, color: '#c9d1d9' },
+  hovertext: hover,
+  hoverinfo: 'text',
+  marker: {
+    size: sizes,
+    color: colors,
+    line: { color: '#0d1117', width: 1.5 },
+    opacity: 0.9,
+  },
+}], {
+  paper_bgcolor: '#0d1117',
+  plot_bgcolor: '#161b22',
+  font: { color: '#c9d1d9', family: '-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif' },
+  xaxis: {
+    title: { text: 'Breadth — how many participants raised this (out of 19)', font: { size: 13 } },
+    gridcolor: '#21262d',
+    range: [2.5, 13.5],
+    dtick: 2,
+    zeroline: false,
+  },
+  yaxis: {
+    title: { text: 'Depth — avg messages spent discussing per participant', font: { size: 13 } },
+    gridcolor: '#21262d',
+    range: [2, 7.5],
+    zeroline: false,
+  },
+  margin: { l: 70, r: 40, t: 20, b: 60 },
+  annotations: [
+    {
+      x: 11, y: 7, text: '<b>CRITICAL</b><br>broad + deep',
+      showarrow: false, font: { size: 11, color: 'rgba(248,81,73,0.5)' },
+    },
+    {
+      x: 3.5, y: 2.5, text: 'niche concerns',
+      showarrow: false, font: { size: 10, color: 'rgba(126,231,135,0.4)' },
+    },
+  ],
+  shapes: [
+    // Quadrant dividers
+    { type: 'line', x0: 6.5, x1: 6.5, y0: 2, y1: 7.5, line: { color: '#21262d', width: 1, dash: 'dot' } },
+    { type: 'line', x0: 2.5, x1: 13.5, y0: 4.3, y1: 4.3, line: { color: '#21262d', width: 1, dash: 'dot' } },
+  ],
+}, {
+  responsive: true,
+  displayModeBar: false,
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds 7 interactive HTML visualizations from Phase 1 structured interviews (19 completed, 33 engaged) to a `phase1/` directory
- Served as static files at `/phase1/`, bypassing Quartz markdown processing
- Adds `phase1/**` to Quartz ignore patterns in `quartz.config.ts`
- Adds a callout link on the homepage (`index.md`) pointing to the dashboard

### Visualizations included

| Tab | What it shows |
|-----|--------------|
| Overview | Research intro, key stats, CTA to participate |
| Problems Map | 10 problems ranked by urgency score, with participant details |
| Urgency Matrix | Bubble scatter — breadth vs depth (Plotly) |
| Solutions Landscape | 21 solutions in 5 maturity columns with hover details |
| Wardley Map | Evolution × value chain with dependency lines (SVG) |
| Actors Network | 30 actors force-directed graph (D3) |
| Sankey | Problem → Solution → Actor flow diagram (Plotly) |

All files are self-contained HTML with data inlined. External deps loaded via CDN (D3 v7, Plotly 2.35.2, Google Fonts).

## Test plan

- [ ] Verify `gov-acc.metagov.org/phase1/` loads the tabbed dashboard after deploy
- [ ] Verify all 7 tabs render correctly
- [ ] Verify homepage callout link navigates to `/phase1/`
- [ ] Verify existing Quartz pages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)